### PR TITLE
python peltool

### DIFF
--- a/modules/pel/datastream.py
+++ b/modules/pel/datastream.py
@@ -41,7 +41,7 @@ class DataStream:
         current index.
         """
         assert self.check_range(num_bytes), "range check failure"
-        o_mv = self.data[self.index : self.index + num_bytes]
+        o_mv = self.data[self.index: self.index + num_bytes]
         self.inc_index(num_bytes)
         return o_mv
 
@@ -65,5 +65,4 @@ class DataStream:
         assert None != is_signed,  "is_signed not defined"
 
         return int.from_bytes(self.get_mem(num_bytes),
-                              byteorder = byte_order, signed = is_signed)
-
+                              byteorder=byte_order, signed=is_signed)

--- a/modules/pel/peltool/comp_id.py
+++ b/modules/pel/peltool/comp_id.py
@@ -1,0 +1,52 @@
+from pel.peltool.pel_values import creatorIDs
+import os
+import json
+
+componentIDs = {}
+
+
+def getCompIDFilePath(creatorID: str) -> str:
+    """
+    Returns the file path to look up the component ID in.
+    The pel_registry module isn't available on the BMC,
+    so just look in /usr/share/... if that module isn't present.
+    """
+    try:
+        import pel_registry
+        file = pel_registry.get_comp_id_file_path(creatorID)
+    except ModuleNotFoundError:
+        # Use the BMC path
+        basePath = '/usr/share/phosphor-logging/pels/'
+        name = creatorID + '_component_ids.json'
+        file = os.path.join(os.path.join(basePath, name))
+
+    return file
+
+
+def getDisplayCompID(componentID: int, creatorID: str) -> str:
+    """
+    Converts a component ID to a name if possible for display.
+    Otherwise it returns the comp id like "0xFFFF"
+    """
+
+    # PHYP's IDs are ASCII
+    if creatorID in creatorIDs and creatorIDs[creatorID] == "PHYP":
+        first = (componentID >> 8) & 0xFF
+        second = componentID & 0xFF
+        if first != 0 and second != 0:
+            return chr(first) + chr(second)
+
+        return "{:04X}".format(componentID)
+
+    # try the comp IDs file named after the creator ID
+    if creatorID not in componentIDs:
+        compIDFile = getCompIDFilePath(creatorID)
+        if os.path.exists(compIDFile):
+            with open(compIDFile, 'r') as file:
+                componentIDs[creatorID] = json.load(file)
+
+    compIDStr = '{:04X}'.format(componentID).upper()
+    if creatorID in componentIDs and compIDStr in componentIDs[creatorID]:
+        return componentIDs[creatorID][compIDStr]
+
+    return "{:04X}".format(componentID)

--- a/modules/pel/peltool/default.py
+++ b/modules/pel/peltool/default.py
@@ -1,0 +1,34 @@
+from pel.datastream import DataStream
+from pel.hexdump import hexdump
+from collections import OrderedDict
+import json
+
+
+class Default:
+    """
+    This represents a section in a PEL that isn't handled by another class.
+    The toJSON function will just hexdump the contents.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.dataLength = sectionLen - 8
+        self.data = self.stream.get_mem(self.dataLength)
+
+    def toJSON(self) -> OrderedDict:
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = "0x{:02X}".format(self.componentID)
+
+        mv = memoryview(self.data)
+        out['Data'] = hexdump(mv)
+
+        return out

--- a/modules/pel/peltool/ext_user_data.py
+++ b/modules/pel/peltool/ext_user_data.py
@@ -1,0 +1,49 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.parse_user_data import ParseUserData
+from pel.peltool.comp_id import getDisplayCompID
+import json
+
+
+class ExtUserData:
+    """
+    This represents the Extended User Data section in a PEL.  It is free form
+    data that the creator knows the contents of.  The component ID, version, and
+    sub-type fields in the section header are used to identify the format.
+
+    This section is used for one subsystem to add FFDC data to a PEL created
+    by another subsystem.  It is basically the same as a UserData section,
+    except it has the creator ID of the section creator stored in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        dataLength = sectionLen - 4 - 8
+        self.creatorID = chr(stream.get_int(1))
+        self.reserved1B = stream.get_int(1)
+        self.reserved2B = stream.get_int(2)
+        self.data = stream.get_mem(dataLength)
+
+    def toJSON(self) -> OrderedDict:
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        parser = ParseUserData(self.creatorID, self.componentID, self.subType,
+                               self.versionID, self.data)
+
+        value = parser.parse()
+
+        j = json.loads(value)
+        if not isinstance(j, dict):
+            out['Data'] = j
+        else:
+            out.update(j)
+
+        return out

--- a/modules/pel/peltool/extend_user_header.py
+++ b/modules/pel/peltool/extend_user_header.py
@@ -1,0 +1,64 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.private_header import getTimestamp
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class ExtendedUserHeader:
+    """
+    This represents the Extended User Header section in a PEL.  It is  a required
+    section.  It contains code versions, an MTMS subsection, and a string called
+    a symptom ID.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.machineType = ""
+        self.serialNumber = ""
+        self.serverFWVersion = ""
+        self.subsystemFWVersion = ""
+        self.reserved4B = 0
+        self.refTime = ""
+        self.reserved1B1 = 0
+        self.reserved1B2 = 0
+        self.reserved1B3 = 0
+        self.symptomIDSize = ""
+        self.symptomID = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.machineType = bytes.decode(self.stream.get_mem(8))
+        self.serialNumber = bytes.decode(self.stream.get_mem(12))
+        self.serverFWVersion = bytes.decode(self.stream.get_mem(16))
+        self.subsystemFWVersion = bytes.decode(self.stream.get_mem(16))
+        self.reserved4B = self.stream.get_int(4)
+        self.refTime = getTimestamp(self.stream)
+        self.reserved1B1 = self.stream.get_int(1)
+        self.reserved1B2 = self.stream.get_int(1)
+        self.reserved1B3 = self.stream.get_int(1)
+        self.symptomIDSize = self.stream.get_int(1)
+        if self.symptomIDSize != 0:
+            self.symptomID = bytes.decode(
+                self.stream.get_mem(self.symptomIDSize))
+        else:
+            self.symptomID = ''
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Reporting Machine Type"] = self.machineType
+        out["Reporting Serial Number"] = self.serialNumber.strip("\u0000")
+        out["FW Released Ver"] = self.serverFWVersion.strip("\u0000")
+        out["FW SubSys Version"] = self.subsystemFWVersion.strip("\u0000")
+        out["Common Ref Time"] = self.refTime
+        out["Symptom Id Len"] = str(self.symptomIDSize)
+        out["Symptom Id"] = self.symptomID.strip("\u0000")
+
+        return out

--- a/modules/pel/peltool/failing_mtms.py
+++ b/modules/pel/peltool/failing_mtms.py
@@ -1,0 +1,38 @@
+from pel.datastream import DataStream
+from pel.peltool.comp_id import getDisplayCompID
+from collections import OrderedDict
+
+
+class FailingMTMS:
+    """
+    This represents the Failing Enclosure MTMS section in a PEL.
+    It is a required section.  In the BMC case, the enclosure is
+    the system enclosure.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.reserved0 = 0
+        self.reserved1 = 0
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.machineType = ""
+        self.serialNumber = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.machineType = bytes.decode(self.stream.get_mem(8))
+        self.serialNumber = bytes.decode(self.stream.get_mem(12))
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Machine Type Model"] = self.machineType.strip("\u0000")
+        out["Serial Number"] = self.serialNumber.strip("\u0000")
+
+        return out

--- a/modules/pel/peltool/imp_partition.py
+++ b/modules/pel/peltool/imp_partition.py
@@ -1,0 +1,62 @@
+from pel.datastream import DataStream
+from pel.peltool.comp_id import getDisplayCompID
+from collections import OrderedDict
+
+
+class ImpactedPartition:
+    """
+    This represents the Impacted Partition section in a PEL.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.primaryPartID = 0
+        self.lpNameLength = 0
+        self.targetLPcount = 0
+        self.logicalPartLogID = 0
+        self.lpName = ""
+        self.targetLPs = []
+
+    def toJSON(self) -> OrderedDict:
+        self.primaryPartID = self.stream.get_int(2)
+        self.lpNameLength = self.stream.get_int(1)
+        self.targetLPcount = self.stream.get_int(1)
+        self.logicalPartLogID = self.stream.get_int(4)
+
+        if self.lpNameLength:
+            self.lpName = bytes.decode(
+                self.stream.get_mem(self.lpNameLength)).rstrip('\x00')
+
+        if self.targetLPcount:
+            for _ in range(self.targetLPcount):
+                self.targetLPs.append(self.stream.get_int(2))
+
+        # PEL sections are 4 byte aligned, so may need
+        # to advance the stream past the padding to get ready
+        # for next section.
+        if self.targetLPcount % 2:
+            _ = self.stream.get_int(2)
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        out["Primary Partition ID"] = "0x{:04X}".format(self.primaryPartID)
+        out["Length of LP Name"] = "0x{:02X}".format(self.lpNameLength)
+        out["Target LP Count"] = "0x{:02X}".format(self.targetLPcount)
+        out["Logical Partition Log ID"] = "0x{:08X}".format(
+            self.logicalPartLogID)
+        out["Primary Partition Name"] = self.lpName
+
+        for i in range(self.targetLPcount):
+            out["Target LP"] = "0x{:04X}".format(self.targetLPs[i])
+
+        return out

--- a/modules/pel/peltool/message_registry.json
+++ b/modules/pel/peltool/message_registry.json
@@ -1,0 +1,4195 @@
+{
+    "PELs":
+    [
+        {
+            "Name": "xyz.openbmc_project.Common.Error.Timeout",
+            "Subsystem": "bmc_firmware",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1001",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "Timeout in ms",
+                        "AdditionalDataPropSource": "TIMEOUT_IN_MSEC"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "This is a generic timeout error",
+                "Message": "An operation timed out",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Error.InternalFailure",
+            "Subsystem": "bmc_firmware",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1002",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "BMC code had a generic internal failure",
+                "Message": "An application had an internal failure",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Error.InvalidArgument",
+            "Subsystem": "user_error",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1003",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "BMC code was given an invalid argument",
+                "Message": "Code was given an invalid argument",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.Common.Error.InsufficientPermission",
+            "Subsystem": "user_error",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1004",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "An operation failed due to insufficient permission",
+                "Message": "An operation failed due to unsufficient permission",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Error.NotAllowed",
+            "Subsystem": "user_error",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1005",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "An operation failed because it isn't allowed",
+                "Message": "An operation failed because it isn't allowed",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Error.NoCACertificate",
+            "Subsystem": "user_error",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1006",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "The server's CA certificate has not been provided",
+                "Message": "The server's CA certificate has not been provided"
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Device.Error.ReadFailure",
+            "Subsystem": "cec_i2c",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1007",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "errno of the failure",
+                        "AdditionalDataPropSource": "CALLOUT_ERRNO"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Sensor device read failure",
+                "Message": "There was a failure when reading a sensor device",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "The action flags are set automatically by the code.",
+                    "Callouts added based on CALLOUT_DEVICE_PATH."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Device.Error.ReadFailure",
+            "Subsystem": "cec_i2c",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1008",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "errno of the failure",
+                        "AdditionalDataPropSource": "CALLOUT_ERRNO"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Device read failure",
+                "Message": "There was a failure when reading a hardware device",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "The action flags are set automatically by the code.",
+                    "Callouts added based on CALLOUT_DEVICE_PATH."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Control.Device.Error.WriteFailure",
+            "Subsystem": "cec_i2c",
+
+            "SRC":
+            {
+                "ReasonCode": "0x1009",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "errno of the failure",
+                        "AdditionalDataPropSource": "CALLOUT_ERRNO"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Device write failure",
+                "Message": "There was a failure when writing to a hardware device",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "The action flags are set automatically by the code.",
+                    "Callouts added based on CALLOUT_DEVICE_PATH"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.Device.Error.WriteFailure",
+            "Subsystem": "cec_i2c",
+
+            "SRC":
+            {
+                "ReasonCode": "0x100A",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "errno of the failure",
+                        "AdditionalDataPropSource": "CALLOUT_ERRNO"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Device write failure",
+                "Message": "There was a failure when writing to a hardware device",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "The action flags are set automatically by the code.",
+                    "Callouts added based on CALLOUT_DEVICE_PATH"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Logging.Error.SentBadPELToHost",
+            "Subsystem": "bmc_firmware",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0x2001",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "The bad PEL ID",
+                        "AdditionalDataPropSource": "BAD_ID"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "The BMC sent the host a malformed PEL",
+                "Message": "The BMC sent the host a malformed PEL",
+                "Notes": [
+                    "The host firmware rejected that PEL."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Logging.Error.BadHostPEL",
+            "Subsystem": "platform_firmware",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x2002",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "The PLID of the invalid PEL",
+                        "AdditionalDataPropSource": "PLID"
+                    },
+                    "7":
+                    {
+                        "Description": "The corresponding OpenBMC event log ID",
+                        "AdditionalDataPropSource": "OBMC_LOG_ID"
+                    },
+                    "8":
+                    {
+                        "Description": "The size of the invalid PEL",
+                        "AdditionalDataPropSource": "PEL_SIZE"
+                    }
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "The host sent the BMC an invalid PEL",
+                "Message": "The host sent the BMC an invalid PEL",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Logging.Error.TestError1",
+            "Subsystem": "platform_firmware",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x2003",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {"Priority": "high", "Procedure": "bmc_code"},
+                        {"Priority": "medium", "SymbolicFRU": "service_docs"}
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "An error for testing",
+                "Message": "This is a test error"
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Logging.Error.Default",
+            "Subsystem": "other_na",
+
+            "SRC":
+            {
+                "ReasonCode": "0x2004",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "This entry is used when no other matching entry is found",
+                "Message": "Unknown (Original event not in message registry)",
+                "Notes": [
+                    "This is used when the actual error name isn't found in ",
+                    "the registry.  The original error name will be stored ",
+                    "in the UserData section that contains the AdditionalData ",
+                    "properties using the key ERROR_NAME.",
+                    "This error may contain callouts if the creator passed ",
+                    "them in.",
+                    "The severity is set by the creator.",
+                    "If this error is seen, then a code change needs to be ",
+                    "made to add the missing error entry to this registry."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Logging.Error.TestError2",
+            "Subsystem": "bmc_firmware",
+            "Severity": "recovered",
+            "ActionFlags": ["report"],
+
+            "SRC":
+            {
+                "ReasonCode": "0x2005",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                   "CalloutList": [
+                        { "Priority": "high", "LocCode": "P0" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "An error for testing",
+                "Message": "This is a test recoverable error",
+                "Notes": [
+                    "This error is not created by BMC code and is ",
+                    "only used for error injection tests."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.Boot",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3001",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure occurred during boot process",
+                "Message": "Failure occurred during boot process",
+                "Notes": [
+                    "Debug traces will be captured in AdditionalData section"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.PrePowerOff",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3002",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure occurred during PHAL pre-poweroff operations",
+                "Message": "Failure occurred during PHAL pre-poweroff operations",
+                "Notes": [
+                    "Severity needs to be set based on needs for this registry.",
+                    "FFDC (First Failure Data Collection) will be collected ",
+                    "and added into PEL."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.devtreeSync",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3003",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure occurred during PHAL devtree sync ",
+                "Message": "Failure occurred during PHAL devtree sync",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.devtreeBackup",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3004",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure occurred during PHAL devtree backup ",
+                "Message": "Failure occurred during PHAL devtree backup",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.HostRunning",
+            "Subsystem": "cec_sp_hostboot_iface",
+            "ComponentID": "0x3000",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3005",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Host did not respond to BMC after a BMC reset",
+                "Message": "Host did not respond to BMC after a BMC reset but hardware indicates it is running",
+                "Notes": [
+                    "System will be left in its current state to ensure host ",
+                    "is not unexpectedly taken down. There is most likely an ",
+                    "issue in the software or hardware communication path ",
+                    "between the BMC and the Host firmware.",
+                    "A BMC dump will be collected with relevant FFDC."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.devtreeReinit",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3006",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure re-initializing BMC to Host data structure",
+                "Message": "Failure occurred during re-initializing BMC to Host data structure",
+                "Notes": [
+                    "The journal should contain more information"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.PHAL.Error.NonFunctionalBootProc",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3007",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Non functional boot processor",
+                "Message": "Non functional boot processor",
+                "Notes": [
+                    "BMC firmware couldn't find functional primary processor",
+                    "required to boot the host",
+                    "Debug traces will be captured in AdditionalData section"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.HardwareIsolation.Error",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3100",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3101",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Failure occurred during hardware isolation operations",
+                "Message": "Failure occurred during hardware isolation operations",
+                "Notes": [
+                    "Severity needs to be set based on needs for this registry.",
+                    "Debug traces will be captured in AdditionalData section"
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Error.HostNotRunning",
+            "Subsystem": "cec_sp_hostboot_iface",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3401",
+                "Words6To9":
+                {
+                }
+            },
+            "Documentation":
+            {
+                "Description": "Host was booting or booted before BMC reset but is now unresponsive",
+                "Message": "Host did not respond to BMC after a BMC reset but it was booting or booted prior to the BMC reboot",
+                "Notes": [
+                    "System will follow recovery policy, resulting in this ",
+                    "error and most likely a a reboot of the host. The issue ",
+                    "is most likely the result of the BMC rebooting while the ",
+                    "host was booting and in a state where it still needed ",
+                    "the BMC to complete its boot."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.ChassisPowerBad",
+            "Subsystem": "input_power_source",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3402",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "Chassis input power is in a bad state",
+                "Message": "Chassis input power is in a bad state, look for other logs with more details",
+                "Notes": [
+                    "The system is most likely in a limited power situation. ",
+                    "There is enough power for the BMC to operate but not the ",
+                    "CEC hardware. Check for UPS or brownout logs."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.PinholeReset",
+            "Subsystem": "cec_op_panel",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3403",
+                "Words6To9":
+                {
+                }
+            },
+            "Documentation":
+            {
+                "Description": "User initiated a pinhole reset via the op-panel",
+                "Message": "User initiated a pinhole reset via the op-panel",
+                "Notes": [
+                    "This is a notification log to record the fact that a ",
+                    "pinhole reset was performed on the BMC, resulting in a ",
+                    "hard reset of the BMC."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Error.CriticalServiceFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3404",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "A critical BMC application has failed on the system",
+                "Message": "A critical BMC application has failed on the system, the BMC is in an undefined state",
+                "Notes": [
+                    "As a part of generating this error log, a BMC dump has ",
+                    "also been generated. Please collect this dump if possible. ",
+                    "The BMC state is undefined but basic services could still ",
+                    "be available. Usually an AC cycle of the entire system is ",
+                    "the best recovery option from this error."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Error.SecurityCheckFail",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3405",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "A firmware security check has failed",
+                "Message": "A firmware security check has failed, most likely something is not configured correctly",
+                "Notes": [
+                    "This log is only generated in the manufacturing ",
+                    "environment and it indicates that something has not ",
+                    "been configured correctly. Use the data in the PEL to ",
+                    "determine what that is."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.BMC.Error.MultiUserTargetFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3406",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to reach BMC Ready state",
+                "Message": "The system has failed to reach BMC Ready state, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "for the BMC to reach Ready state has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Chassis.Error.PowerOnFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3407",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to reach chassis power on state",
+                "Message": "The system has failed to reach chassis power on state, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "for the BMC to power on the chassis has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Chassis.Error.PowerOffFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3408",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to reach chassis power off state",
+                "Message": "The system has failed to reach chassis power off state, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "for the BMC to power off the chassis has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Host.Error.HostStartFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3409",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to start the host firmware",
+                "Message": "The system has failed to start the host firmware, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "for the BMC to start the host has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Host.Error.HostStartMinFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3410",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to start the host firmware",
+                "Message": "The system has failed to start the host firmware, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "for the BMC to start the host has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Host.Error.HostShutdownFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3411",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to shutdown the host firmware",
+                "Message": "The system has failed to shutdown the host firmware, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "to shutdown the host firmware has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Host.Error.HostStopFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3412",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to stop the host firmware",
+                "Message": "The system has failed to stop the host firmware, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "to stop the host firmware has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Host.Error.HostRebootFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3413",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The system has failed to reboot the host firmware",
+                "Message": "The system has failed to reboot the host firmware, look for other errors",
+                "Notes": [
+                    "This log indicates a critical BMC application required ",
+                    "to reboot the host firmware has failed to start  ",
+                    "successfully. Look in the log for other errors indicating ",
+                    "what has failed."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Error.HostQuiesce",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3400",
+            "SRC":
+            {
+                "ReasonCode": "0x3414",
+                "Words6To9":
+                {
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "next_level_support"}]
+                }
+            ],
+            "Documentation":
+            {
+                "Description": "The host firmware has failed to boot",
+                "Message": "The host firmware has failed to boot and has entered a Quiesce state. Look for other errors.",
+                "Notes": [
+                    "This log indicates that the host firmware has failed to ",
+                    "boot and all retries have been exhausted. There should be  ",
+                    "other logs with more details on the boot failure reason. "
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Processor.Error.SbeChipOpFailure",
+            "Subsystem": "processor_chip",
+            "ComponentID": "0x3500",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3500",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "[0:15] chip position, [16:23] command class, [24:31] command type",
+                        "AdditionalDataPropSource": "SRC6"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "chipop failure with SBE provided FFDC",
+                "Message": "chipop request failure reported by SBE",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "Callouts added based on SBE provided FFDC.",
+                    "SBE provided additional debug data included as part of the",
+                    "additional user data section."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Processor.Error.SbeChipOpTimeout",
+            "Subsystem": "processor_chip",
+            "ComponentID": "0x3500",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3501",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "[0:15] chip position, [16:23] command class, [24:31] command type",
+                        "AdditionalDataPropSource": "SRC6"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "SBE chipop timeout",
+                "Message": "chipop timeout reported during SBE communication",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "Check SBE Dump associated to this error to debug the failure."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Processor.Error.SbeChipOpInvalidState",
+            "Subsystem": "processor_chip",
+            "ComponentID": "0x3500",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3502",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "[0:15] chip position, [16:23] command class, [24:31] command type",
+                        "AdditionalDataPropSource": "SRC6"
+                    },
+                    "7":
+                    {
+                        "Description": "Value of SBE state",
+                        "AdditionalDataPropSource": "SRC7"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "The SBE on this processor is not in a state where chipOps can be issued",
+                "Message": "SBE Chipop is not allowed due to invalid SBE state ",
+                "Notes": [
+                    "The severity is set by the creator."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Processor.Error.SbeBootFailure",
+            "Subsystem": "processor_chip",
+            "ComponentID": "0x3500",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3503",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "[0:15] chip position",
+                        "AdditionalDataPropSource": "SRC6"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Boot failure with SBE provided FFDC",
+                "Message": "Boot failure reported by SBE",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "Callouts added based on SBE provided FFDC.",
+                    "SBE provided additional debug data included as part of the",
+                    "additional user data section."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Processor.Error.SbeBootTimeout",
+            "Subsystem": "processor_chip",
+            "ComponentID": "0x3500",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3504",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "SBE Boot timeout",
+                "Message": "timeout reported during SBE boot process",
+                "Notes": [
+                    "The severity is set by the creator.",
+                    "Check SBE Dump associated to this error to debug the failure."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Attn.Error.Terminate",
+            "Subsystem": "cec_hardware",
+            "Severity": "non_error",
+
+            "SRC":
+            {
+                "ReasonCode": "0xD138",
+                "SymptomIDFields": [ "SRCWord3", "SRCWord4", "SRCWord5", "SRCWord6", "SRCWord7", "SRCWord8", "SRCWord9" ],
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Status shows TI special attention active",
+                "Message": "TI special attention detected",
+                "Notes": [
+                    "This entry is for any TI special attention event ",
+                    "reported by the attention handler component"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Attn.Error.Fail",
+            "Subsystem": "bmc_firmware",
+            "Severity": "unrecoverable_loss_of_function",
+
+            "SRC":
+            {
+                "ReasonCode": "0xD13E",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "Error code from attention handler",
+                        "AdditionalDataPropSource": "ERROR_CODE"
+                    }
+                }
+            },
+            "Documentation":
+            {
+                "Description": "The attention handler encountered an error",
+                "MessageArgSources" : ["SRCWord6"],
+                "Message": "Attention handler error %1",
+                "Notes": [
+                    "Attention handler will provide error code"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Attn.Error.Vital",
+            "Subsystem": "processor_chip",
+            "Severity": "critical",
+
+            "SRC":
+            {
+                "ReasonCode": "0xD16D",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Status shows SBE vital attention active",
+                "Message": "SBE vital attention detected",
+                "Notes": [
+                    "This entry is for any SBE vital attention event ",
+                    "reported by the attention handler component"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.HwDiags.Error.Checkstop",
+            "PossibleSubsystems": [
+                "processor", "processor_fru", "processor_unit", "processor_bus",
+                "memory_ctlr", "memory_bus", "memory_dimm", "memory_fru",
+                "phb", "cec_hardware", "cec_clocks", "cec_tod", "others"
+            ],
+            "Severity": "unrecoverable",
+            "ActionFlags": [ "service_action", "report", "call_home" ],
+
+            "SRC":
+            {
+                "ReasonCode": "0xE510",
+                "SymptomIDFields": [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "AdditionalDataPropSource": "SRC6"
+                    },
+                    "7":
+                    {
+                        "AdditionalDataPropSource": "SRC7"
+                    },
+                    "8":
+                    {
+                        "AdditionalDataPropSource": "SRC8"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "A system checkstop attention has occurred",
+                "MessageArgSources" : [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Message": "Error Signature: %1 %2 %3"
+            }
+        },
+
+        {
+            "Name": "org.open_power.HwDiags.Error.Predictive",
+            "PossibleSubsystems": [
+                "processor", "processor_fru", "processor_unit", "processor_bus",
+                "memory_ctlr", "memory_bus", "memory_dimm", "memory_fru",
+                "phb", "cec_hardware", "cec_clocks", "cec_tod", "others"
+            ],
+            "Severity": "predictive",
+            "ActionFlags": [ "service_action", "report", "call_home" ],
+
+            "SRC":
+            {
+                "ReasonCode": "0xE511",
+                "SymptomIDFields": [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "AdditionalDataPropSource": "SRC6"
+                    },
+                    "7":
+                    {
+                        "AdditionalDataPropSource": "SRC7"
+                    },
+                    "8":
+                    {
+                        "AdditionalDataPropSource": "SRC8"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "A hardware attention requiring service has occurred",
+                "MessageArgSources" : [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Message": "Error Signature: %1 %2 %3"
+            }
+        },
+
+        {
+            "Name": "org.open_power.HwDiags.Error.Informational",
+            "PossibleSubsystems": [
+                "processor", "processor_fru", "processor_unit", "processor_bus",
+                "memory_ctlr", "memory_bus", "memory_dimm", "memory_fru",
+                "phb", "cec_hardware", "cec_clocks", "cec_tod", "others"
+            ],
+            "Severity": "non_error",
+            "ActionFlags": [ "hidden", "dont_report" ],
+
+            "SRC":
+            {
+                "ReasonCode": "0xE512",
+                "SymptomIDFields": [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "AdditionalDataPropSource": "SRC6"
+                    },
+                    "7":
+                    {
+                        "AdditionalDataPropSource": "SRC7"
+                    },
+                    "8":
+                    {
+                        "AdditionalDataPropSource": "SRC8"
+                    }
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Manual analysis was initiated via the command line. FFDC only.",
+                "MessageArgSources" : [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "Message": "Error Signature: %1 %2 %3"
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.InputFault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15F0",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "SymbolicFRU": "pwrsply" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Power Supply input power fault",
+                "Message": "A power supply has indicated an input or under voltage condition.",
+                "Notes": [
+                    "Check the power supply cabling and/or input power ",
+                    "source. The PWRSPLY procedure is used rather than ",
+                    "calling out a location code, as typically these faults ",
+                    "are related to the supplied power, the cable, or the ",
+                    "cable connectors. If the input fault resolves down to an ",
+                    "issue with the power supply itself, the power supply ",
+                    "indicating this input fault should be called out. Add the ",
+                    "CALLOUT_INVENTORY_PATH to the additional data, and set the",
+                    "CALLOUT_PRIORITY to something other than high."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.Fault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15F1",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Power Supply power fault",
+                "Message": "The power supply detected a fault condition, see AdditionalData for further details.",
+                "Notes": [
+                    "The power supply reporting the fault should be called ",
+                    "out using the CALLOUT_INVENTORY_PATH keyword. Include ",
+                    "specific fault, STATUS_* details, and code level in the ",
+                    "AdditionalData section."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.CommFault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15F2",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Power Supply non-power fault",
+                "Message": "A communication failure occurred talking to the power supply",
+                "Notes": [
+                    "Communication problems with the power supply could be ",
+                    "the power supply, or any hardware between it and the ",
+                    "BMC. Reporting the error should be passing in a call ",
+                    "out using CALLOUT_DEVICE_PATH."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.Missing",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15F6",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {
+                            "Priority": "high",
+                            "SymbolicFRUTrusted": "pwrsply",
+                            "UseInventoryLocCode": true
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Power Supply is missing",
+                "Message": "A power supply that should be present is missing",
+                "Notes": [
+                    "The CalloutList should use the PWRSPLY symbolic FRU ",
+                    "with the trusted location code property.  The ",
+                    "location code in this callout is obtained from ",
+                    "the passed in CALLOUT_INVENTORY_PATH value."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.NotSupported",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15F7",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Power Supply configuration is not supported",
+                "Message": "The power supply configuration is not supported",
+                "Notes": [
+                    "The combination of power supplies detected in the ",
+                    "system is not supported. This could be caused by ",
+                    "mismatched models, less than expected number of power ",
+                    "supplies, or other unsupported characteristics."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.FanFault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x15FF",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Power Supply fan fault",
+                "Message": "A power supply indicated a fan fault has occurred",
+                "Notes": [
+                    "The power supply reporting the fault should be called ",
+                    "out using the CALLOUT_INVENTORY_PATH keyword. Include ",
+                    "specific fault, STATUS_* details, and code level in the ",
+                    "AdditionalData section."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.PowerSupply.Error.IoutOCFault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x1B01",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Power Supply output over-current power fault",
+                "Message": "A power supply has indicated an output over-current condition."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Shutdown.Power.Error.Blackout",
+            "Subsystem": "power",
+            "ActionFlags": [ "report", "service_action" ],
+            "ComponentID": "0x2700",
+
+            "SRC":
+            {
+                "Type": "11",
+                "ReasonCode": "0x00AC",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "SymbolicFRU": "ac_module"}
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Input power was lost while the system was powered on.",
+                "Message": "Input power was lost while the system was powered on.",
+                "Notes": [
+                    "Input power was lost while system powered on.",
+                    "The CalloutList should use the ACMODUL symbolic FRU."
+                ]
+            }
+        },
+
+        {
+           "Name": "xyz.openbmc_project.Power.PowerSupply.Error.PSKillFault",
+            "Subsystem": "power_supply",
+            "ActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2500",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A power supply fault is potentially preventing the power supply from allowing the system to power on.",
+                "Message": "Power supply PSKill_fault",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.Shutdown",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2600",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A power off was issued because a power fault was detected",
+                "Message": "A power off was issued because a power fault was detected",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.State.Shutdown.Power.Error.Regulator",
+            "Subsystem": "power_control_hw",
+            "Severity": "critical_system_term",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2602",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "System": "ibm,rainier",
+                    "CalloutList": [
+                        {
+                            "Priority": "high",
+                            "LocCode": "P0-C5"
+                        },
+                        {
+                            "Priority": "medium",
+                            "LocCode": "P0"
+                        }
+                    ]
+                },
+                {
+                    "System": "ibm,everest",
+                    "CalloutList": [
+                        {
+                            "Priority": "high",
+                            "LocCode": "P0-C59"
+                        },
+                        {
+                            "Priority": "medium",
+                            "LocCode": "P0"
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A power off was issued because a regulator for standby power faulted",
+                "Message": "A power off was issued because a regulator for standby power faulted",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PowerSequencerPGOODFault",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2610",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "INPUT_NAME", "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "PCIE_SLOT0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C0" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C1" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT2", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C2" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT3", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C3" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT4", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C4" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT5", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C5" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT6", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C6" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT7", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C7" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT8", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C8" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT9", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C9" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT10", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C10" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PCIE_SLOT11", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C11" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12A", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12B", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12C", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12D", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12L", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12M", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12N", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12P", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12PCIE", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12Q", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_12R", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VDN_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VDN_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VCS_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VCS_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VIO_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VIO_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VPCIE_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_VPCIE_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VPCIE", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C58" },
+                                    { "Priority": "medium", "LocCode": "P0-C60" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VPCIE", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C16" },
+                                    { "Priority": "medium", "LocCode": "P0-C13" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VPCIE", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C16" },
+                                    { "Priority": "medium", "LocCode": "P0-C20" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VPCIE", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C58" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "0V_USB_front", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "usb_pgood" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VDN", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C63" },
+                                    { "Priority": "medium", "LocCode": "P0-C60" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VDN", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C12" },
+                                    { "Priority": "medium", "LocCode": "P0-C13" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VDN", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C21" },
+                                    { "Priority": "medium", "LocCode": "P0-C20" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VDN", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C54" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VIO", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C63" },
+                                    { "Priority": "medium", "LocCode": "P0-C60" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VIO", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C12" },
+                                    { "Priority": "medium", "LocCode": "P0-C13" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VIO", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C21" },
+                                    { "Priority": "medium", "LocCode": "P0-C20" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VIO", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C54" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_PSU1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "E0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_PSU2", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "E1" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_PSU3", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "E2" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "PGOOD_PSU4", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "E3" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "The power sequencer chip detected a PGOOD fault",
+                "Message": "The power sequencer chip detected a PGOOD fault",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PowerSequencerVoltageFault",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2620",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "RAIL_NAME", "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "12.0V", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "5.0V_USB", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "usb_pgood" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "5.0V_DASD", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "medium", "LocCode": "P1" },
+                                    { "Priority": "medium", "LocCode": "P2" },
+                                    { "Priority": "medium", "LocCode": "P3" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "3.3VA", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "3.3VB", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "3V3IO", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C17" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "1.5V", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "1.1V", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "VDDA_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "VDDB_DCM0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C15" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "VDDA_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "VDDB_DCM1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C23" },
+                                    { "Priority": "medium", "LocCode": "P0-C24" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP03_AVDD", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C58" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "medium", "LocCode": "P0-C61" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP12_AVDD", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C16" },
+                                    { "Priority": "medium", "LocCode": "P0-C14" },
+                                    { "Priority": "medium", "LocCode": "P0-C19" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VDD0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C62" },
+                                    { "Priority": "medium", "LocCode": "P0-C61" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VDD1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C60" },
+                                    { "Priority": "medium", "LocCode": "P0-C61" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VDD0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C13" },
+                                    { "Priority": "medium", "LocCode": "P0-C14" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VDD1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C15" },
+                                    { "Priority": "medium", "LocCode": "P0-C14" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VDD0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C18" },
+                                    { "Priority": "medium", "LocCode": "P0-C19" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VDD1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C20" },
+                                    { "Priority": "medium", "LocCode": "P0-C19" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VDD0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C57" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VDD1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C55" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VCS0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C63" },
+                                    { "Priority": "medium", "LocCode": "P0-C61" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP0_VCS1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C59" },
+                                    { "Priority": "medium", "LocCode": "P0-C61" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VCS0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C12" },
+                                    { "Priority": "medium", "LocCode": "P0-C14" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP1_VCS1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C16" },
+                                    { "Priority": "medium", "LocCode": "P0-C14" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VCS0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C17" },
+                                    { "Priority": "medium", "LocCode": "P0-C19" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP2_VCS1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C21" },
+                                    { "Priority": "medium", "LocCode": "P0-C19" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VCS0", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C58" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "CP3_VCS1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0-C54" },
+                                    { "Priority": "medium", "LocCode": "P0-C56" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "12.0VCS", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "3.3VCS", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "1.1V_Current", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "5.0V_USB_Current", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "usb_pgood" },
+                                    { "Priority": "medium", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "5.0V_DASD_Current", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "medium", "LocCode": "P1" },
+                                    { "Priority": "medium", "LocCode": "P2" },
+                                    { "Priority": "medium", "LocCode": "P3" },
+                                    { "Priority": "low", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "12.0VN", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "12.0VP", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "12.0VQ", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "12.0VR", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "pgood_part" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "ThermalDiode1", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "ThermalDiode2", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "ThermalDiode3", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "ADValue": "ThermalDiode4", "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "LocCode": "P0" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "The power sequencer chip detected a voltage fault",
+                "Message": "The power sequencer chip detected a voltage fault",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Regulators.Error.PhaseFault.N",
+            "Subsystem": "power",
+            "Severity": "predictive_redundancy_loss",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2700",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Voltage regulator phase fault detected; device now at redundancy level N (no redundant phases)",
+                "Message": "Voltage regulator phase fault detected; device now at redundancy level N (no redundant phases)",
+                "Notes": [
+                    "CALLOUT_INVENTORY_PATH should be specified in the ",
+                    "AdditionalData property of the event log so that ",
+                    "the device is called out but not the communication path."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Regulators.Error.PhaseFault.NPlus1",
+            "Subsystem": "power",
+            "Severity": "non_error",
+            "MfgSeverity": "predictive_redundancy_loss",
+            "ActionFlags": ["report"],
+            "MfgActionFlags": ["service_action", "report", "call_home"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2701",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Voltage regulator phase fault detected; device now at redundancy level N+1 (one redundant phase)",
+                "Message": "Voltage regulator phase fault detected; device now at redundancy level N+1 (one redundant phase)",
+                "Notes": [
+                    "CALLOUT_INVENTORY_PATH should be specified in the ",
+                    "AdditionalData property of the event log so that ",
+                    "the device is called out but not the communication path."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Regulators.Error.WriteVerification",
+            "Subsystem": "power",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x2900",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A write verification error occurred on a device",
+                "Message": "A write verification error occurred on a device",
+                "Notes": [
+                    "This error occurs when a device register is written, ",
+                    "read back, and the two values do not match.  This is ",
+                    "also called a read-back error.  The device should be ",
+                    "identified using the CALLOUT_DEVICE_PATH or ",
+                    "CALLOUT_IIC_BUS/CALLOUT_IIC_ADDR keywords in the ",
+                    "AdditionalData property of the event log.  This will ",
+                    "cause the device and the hardware in the communication ",
+                    "path to be called out."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.UPS.Error.Battery.Discharging",
+            "Subsystem": "power",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x4201",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "The Uninterruptible Power Supply (UPS) battery is discharging and providing power to the system due to a utility failure",
+                "Message": "The Uninterruptible Power Supply (UPS) battery is discharging and providing power to the system due to a utility failure",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.UPS.Error.Battery.Low",
+            "Subsystem": "power",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x4203",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "The Uninterruptible Power Supply (UPS) battery level is low",
+                "Message": "The Uninterruptible Power Supply (UPS) battery level is low",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Regulators.Error.ConfigFile",
+            "Subsystem": "power",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xA013",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A regulators configuration file error occurred",
+                "Message": "A regulators configuration file error occurred",
+                "Notes": [
+                    "The regulators configuration file could not be found, ",
+                    "could not be read, or had invalid contents."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Regulators.Error.ConfigFile.Critical",
+            "Subsystem": "power",
+            "Severity": "critical_system_term",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xA014",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A critical regulators configuration file error occurred",
+                "Message": "A critical regulators configuration file error occurred",
+                "Notes": [
+                    "The regulators configuration file could not be found, ",
+                    "could not be read, or had invalid contents.  As a result ",
+                    "voltage regulators could not be configured, and the ",
+                    "chassis could not be powered on."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PowerSequencerFault",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xD000",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "LocCode": "P0" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "The power sequencer chip detected a fault",
+                "Message": "The power sequencer chip detected a fault",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PowerOnTimeout",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+            "Severity": "critical",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xD002",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "LocCode": "P0" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "System power failed to turn on within timeout period",
+                "Message": "System power failed to turn on within timeout period",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PowerOffTimeout",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+            "Severity": "critical",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xD008",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "LocCode": "P0" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "System power failed to turn off within timeout period",
+                "Message": "System power failed to turn off within timeout period",
+                "Notes": [
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.Internal",
+            "Subsystem": "power",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xE000",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "An internal firmware error occurred",
+                "Message": "An internal firmware error occurred",
+                "Notes": [
+                    "The error details must be provided in the AdditionalData ",
+                    "property of the event log."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.I2C",
+            "Subsystem": "cec_i2c",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xE100",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "An I2C error occurred communicating with a device",
+                "Message": "An I2C error occurred communicating with a device",
+                "Notes": [
+                    "The device should be identified using the ",
+                    "CALLOUT_DEVICE_PATH or CALLOUT_IIC_BUS/CALLOUT_IIC_ADDR ",
+                    "keywords in the AdditionalData property of the event ",
+                    "log.  This will cause the device and the hardware in the ",
+                    "communication path to be called out."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.PMBus",
+            "Subsystem": "power",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xE200",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A PMBus error occurred on a device",
+                "Message": "A PMBus error occurred on a device",
+                "Notes": [
+                    "This error occurs when the I2C communication was ",
+                    "successful, but the PMBus value read is invalid or ",
+                    "unsupported.  CALLOUT_INVENTORY_PATH should be specified ",
+                    "in the AdditionalData property of the event log so that ",
+                    "the device is called out but not the communication path."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Power.Error.DBus",
+            "Subsystem": "power",
+            "ComponentID": "0x2700",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0xE300",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A firmware inter-process communication (D-Bus) error occurred",
+                "Message": "A firmware inter-process communication (D-Bus) error occurred"
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Fan.Error.Fault",
+            "Subsystem": "power_fans",
+            "ComponentID": "0x2800",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x76F0",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Fan rotor fault",
+                "Message": "Fan rotor fault",
+                "Notes": [
+                    "This error occurs when a fan rotor has been faulted for a ",
+                    "certain amount of time.  The callout is the fan which is ",
+                    "passed in with CALLOUT_INVENTORY_PATH.  The severity is ",
+                    "passed in during creation and will be either informational ",
+                    "or unrecoverable.  The action flags use the defaults and ",
+                    "vary based on the severity."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Fan.Error.Missing",
+            "Subsystem": "power_fans",
+            "ComponentID": "0x2800",
+            "Severity": "unrecoverable_redundancy_loss",
+            "ActionFlags": ["service_action", "report", "call_home"],
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x76F1",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "System": "ibm,rainier",
+                    "CalloutList": [
+                        {
+                          "Priority": "high",
+                          "SymbolicFRUTrusted": "air_mover",
+                          "UseInventoryLocCode": true
+                        },
+                        {
+                            "Priority": "low",
+                            "LocCode": "P0"
+                        }
+                    ]
+                },
+                {
+                    "System": "ibm,everest",
+                    "CalloutList": [
+                        {
+                          "Priority": "high",
+                          "SymbolicFRUTrusted": "air_mover",
+                          "UseInventoryLocCode": true
+                        },
+                        {
+                            "Priority": "low",
+                            "LocCode": "P1"
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "A fan is missing",
+                "Message": "A fan is missing",
+                "Notes": [
+                    "This error occurs when a fan has been missing for a ",
+                    "certain amount of time.  The first callout is the ",
+                    "symbolic FRU AIR_MOVR that has the trusted fan location ",
+                    "code, which it gets using the passed in ",
+                    "CALLOUT_INVENTORY_PATH.  The second callout is the FRU ",
+                    "where the controller and GPIO expander are."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Fan.Presence.Error.Detection",
+            "ComponentID": "0x2800",
+            "Subsystem": "power_fans",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "MfgSeverity": "predictive",
+            "MfgActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x76F2",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "System": "ibm,rainier",
+                    "CalloutList": [
+                        {"Priority": "medium", "LocCode": "P0"}
+                    ]
+                },
+                {
+                    "System": "ibm,everest",
+                    "CalloutList": [
+                        {"Priority": "medium", "LocCode": "P1"}
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Presence detect methods for the same fan disagree",
+                "Message": "Presence detect methods for the same fan disagree",
+                "Notes": [
+                    "This error occurs when there is more than one way to detect",
+                    "fan presence, and they don't all agree.  For example, the",
+                    "GPIO says a fan isn't present, but the tach readings are",
+                    "nonzero.  This is informational, unless in manufacturing.",
+                    "The fan FRU is passed in as a high priority callout.",
+                    "The FRU the GPIO source is on is called out medium."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Fan.Error.FanControllerOffline",
+            "ComponentID": "0x2800",
+            "Subsystem": "power_fans",
+            "Severity": "critical_system_term",
+            "ActionFlags": ["service_action", "report", "call_home"],
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x76F3",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "System": "ibm,rainier",
+                    "CalloutList": [
+                        {"Priority": "high", "LocCode": "P0-C5"},
+                        {"Priority": "medium_group_a", "LocCode": "P0-T12", "SymbolicFRUTrusted": "fan_cable"},
+                        {"Priority": "medium_group_a", "LocCode": "P0-T17", "SymbolicFRUTrusted": "cable_continued"},
+                        {"Priority": "low", "LocCode": "P0"}
+                    ]
+                },
+                {
+                    "System": "ibm,everest",
+                    "CalloutList": [
+                        {"Priority": "high", "LocCode": "P0-C0"},
+                        {"Priority": "medium", "LocCode": "P1"},
+                        {"Priority": "low", "LocCode": "P0"}
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "The fan controller device is offline",
+                "Message": "The fan controller is offline.  The system must be powered off.",
+                "Notes": [
+                    "The device that controls the fans is offline so the fan",
+                    "targets and speeds are unknown.  The system will be shut",
+                    "down to preserve thermal safety.  There may be an I2C",
+                    "or power problem with the device."
+                ]
+            }
+        },
+
+        {
+             "Name": "xyz.openbmc_project.Fan.Presence.Error.GPIODeviceUnavailable",
+             "Subsystem": "power_fans",
+             "ComponentID": "0x2800",
+             "Severity": "unrecoverable_redundancy_loss",
+             "ActionFlags": ["service_action", "report", "call_home"],
+
+             "SRC": {
+                 "Type": "11",
+                 "ReasonCode": "0x76F4",
+                 "Words6To9": {}
+             },
+
+             "Callouts": [
+                 {
+                     "System" : "ibm,rainier",
+                     "CalloutList": [
+                         {"Priority": "high", "LocCode": "P0-C5"},
+                         {"Priority": "medium_group_a", "LocCode": "P0-T12","SymbolicFRUTrusted": "fan_cable"},
+                         {"Priority": "medium_group_a", "LocCode": "P0-T17","SymbolicFRUTrusted": "cable_continued"},
+                         {"Priority": "low", "LocCode": "P0"}
+                     ]
+                 },
+                 {
+                     "System" : "ibm,everest",
+                     "CalloutList": [
+                         {"Priority": "high", "LocCode": "P0-C0"},
+                         {"Priority": "medium", "LocCode": "P1"},
+                         {"Priority": "low", "LocCode": "P0"}
+                     ]
+                 }
+             ],
+
+             "Documentation": {
+                 "Description": "Fan GPIO sensors not present",
+                 "Message": "Fan GPIO sensors not present",
+                 "Notes": [
+                     "The device that reports fan presence is not functioning."
+                 ]
+             }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerfLossHigh",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2801",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor exceeded its performance loss threshold.",
+                "Message": "A temperature sensor exceeded its performance loss threshold.",
+                "Notes": [
+                    "A temperature sensor crossed its performance loss threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added.",
+                    "Otherwise, CALLOUT_INVENTORY_PATH will be passed in to add",
+                    "a FRU callout."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerfLossHighClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x2802",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp_back" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is under its performance loss threshold.",
+                "Message": "A temperature sensor is under its performance loss threshold.",
+                "Notes": [
+                    "A temperature sensor crossed under its performance loss threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureWarningHigh",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2803",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor exceeded its warning threshold.",
+                "Message": "A temperature sensor exceeded its warning threshold.",
+                "Notes": [
+                    "A temperature sensor crossed its warning threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added.",
+                    "Otherwise, CALLOUT_INVENTORY_PATH will be passed in to add",
+                    "a FRU callout."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureWarningHighClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x2804",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp_back" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is under its warning threshold.",
+                "Message": "A temperature sensor is under its warning threshold.",
+                "Notes": [
+                    "A temperature sensor crossed under its warning threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalHigh",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2805",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor exceeded its critical threshold.",
+                "Message": "A temperature sensor exceeded its critical threshold.",
+                "Notes": [
+                    "A temperature sensor crossed its critical threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added.",
+                    "Otherwise, CALLOUT_INVENTORY_PATH will be passed in to add",
+                    "a FRU callout."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalHighClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x2806",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "ambient_temp_back" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is under its critical threshold.",
+                "Message": "A temperature sensor is under its critical threshold.",
+                "Notes": [
+                    "A temperature sensor crossed under its critical threshold value",
+                    "If it is the ambient sensor, then a symbolic FRU will be added."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.SoftShutdownAlarmHigh",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2807",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {
+                          "Priority": "high",
+                          "SymbolicFRU": "ambient_temp"
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "The ambient temperature passed the EPOW3 limit.",
+                "Message": "The ambient temperature passed the EPOW3 limit. The system will shut down if temp doesn't decrease.",
+                "Notes": [
+                    "This error occurs when the ambient temperature surpassed",
+                    "the EPOW3 shutdown limit."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.SoftShutdownAlarmHighClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x2808",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {
+                          "Priority": "high",
+                          "SymbolicFRU": "ambient_temp_back"
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "The ambient temperature is back under the EPOW3 limit.",
+                "Message": "The ambient temperature is back under the EPOW3 limit."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.HardShutdownAlarmHigh",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2809",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {
+                          "Priority": "high",
+                          "SymbolicFRU": "ambient_temp"
+                        }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "The ambient temperature passed the EPOW4 limit.",
+                "Message": "The ambient temperature passed the EPOW4 limit. The system will shut down",
+                "Notes": [
+                    "This error occurs when the ambient temperature surpassed",
+                    "the EPOW4 shutdown limit."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.AltitudeWarningHigh",
+            "Subsystem": "ext_env",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x280A",
+                "Words6To9": {}
+            },
+
+            "CalloutsUsingAD": {
+                "ADName": "SENSOR_NAME",
+                "CalloutsWithTheirADValues": [
+                    {
+                        "ADValue": "/xyz/openbmc_project/sensors/altitude/Altitude",
+                        "Callouts": [
+                            {
+                                "CalloutList": [
+                                    { "Priority": "high", "SymbolicFRU": "altitude" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+
+            "Documentation": {
+                "Description": "An altitude sensor exceeded its warning threshold.",
+                "Message": "An altitude sensor exceeded its warning threshold.",
+                "Notes": [
+                    "The virtual altitude sensor crossed its warning threshold value",
+                    " and a symbolic FRU will be added."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.AltitudeWarningHighClear",
+            "Subsystem": "ext_env",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x280B",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "An altitude sensor is under its warning threshold.",
+                "Message": "An altitude sensor is under its warning threshold.",
+                "Notes": [
+                    "The virtual altitude sensor is under its warning threshold value",
+                    " and a symbolic FRU will be added."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.VoltageCriticalLow",
+            "Subsystem": "cec_tod",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x280C",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A voltage sensor went below its critical low threshold.",
+                "Message": "A voltage sensor went below its critical low threshold."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.VoltageCriticalLowClear",
+            "Subsystem": "cec_tod",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+
+            "SRC": {
+                "ReasonCode": "0x280D",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A voltage sensor is over its critical low threshold.",
+                "Message": "A voltage sensor is over its critical low threshold."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureWarningLow",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x280E",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is under its low warning threshold.",
+                "Message": "A temperature sensor is under its low warning threshold.",
+                "Notes": [
+                    "A temperature sensor crossed its low warning threshold value",
+                    "CALLOUT_INVENTORY_PATH will be passed in to add a FRU callout."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureWarningLowClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x280F",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is above its low warning threshold.",
+                "Message": "A temperature sensor is above its low warning threshold.",
+                "Notes": [
+                    "A temperature sensor crossed above its low warning threshold value."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalLow",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "predictive",
+            "ActionFlags": ["service_action", "report"],
+
+            "SRC": {
+                "ReasonCode": "0x2810",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is under its low critical threshold.",
+                "Message": "A temperature sensor is under its low critical threshold.",
+                "Notes": [
+                    "A temperature sensor crossed its low critical threshold value",
+                    "CALLOUT_INVENTORY_PATH will be passed in to add a FRU callout."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalLowClear",
+            "Subsystem": "power",
+            "ComponentID": "0x2800",
+            "Severity": "non_error",
+            "ActionFlags": ["report"],
+            "EventType": "env_normal",
+
+            "SRC": {
+                "ReasonCode": "0x2811",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "A temperature sensor is over its low critical threshold.",
+                "Message": "A temperature sensor is over its low critical threshold.",
+                "Notes": [
+                    "A temperature sensor crossed above its critical threshold value"
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.InvalidEepromPath",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4000",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description": "Errno of the failure.",
+                        "AdditionalDataPropSource": "CALLOUT_ERRNO"
+                    }
+                }
+            },
+
+            "Documentation": {
+                "Description": "A path access error ocurred",
+                "Message": "An EEPROM path access error occurred.",
+                "Notes": [
+                    "This error occurs when parser is unable to access",
+                    "EEPROM path. Errno and device path are captured as",
+                    "additional data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.InvalidVPD",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4001",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation": {
+                "Description": "Invalid VPD data.",
+                "Message": "A VPD data exception occurred.",
+                "Notes": [
+                    "This error occurs when VPD data is found to be",
+                    "invalid. This can be when VPD file is missing out",
+                    "mandatory records.Inventory path is captured in",
+                    "additional data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.EccCheckFailed",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4002",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation": {
+                "Description": "Invalid VPD ecc data.",
+                "Message": "A VPD ecc exception occurred.",
+                "Notes": [
+                    "This error occurs when VPD ecc check fails for the FRU.",
+                    "Inventory path for the failed FRU is captured in additonal",
+                    "data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.InvalidJson",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4003",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Invalid Json",
+                "Message": "A Json failure occurred.",
+                "Notes": [
+                    "This error occurs when parser fails to access",
+                    "Json file or there is any issue with Json data.",
+                    "Failed Json path and cause of failure is captured",
+                    "in additional data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.BlankSystemVPD",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4004",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation": {
+                "Description": "System VPD restore failed",
+                "Message": "A system VPD restoration error occurred.",
+                "Notes": [
+                    "This error occurs when restoring of system VPD fails.",
+                    "The FRU path and reason for failure is captured in",
+                    "additional data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.DbusFailure",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4005",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Dbus exception",
+                "Message": "A Dbus internal error occurred.",
+                "Notes": [
+                    "This error occurs when Dbus operation fails.",
+                    "Exceptions details are captured in additonal",
+                    "data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.UnknownSystemType",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4006",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                   "CalloutList": [
+                        { "Priority": "high", "LocCode": "P0" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Unknown System Type",
+                "Message": "System type not supported in DTB table.",
+                "Notes": [
+                    "System type comes from combination of HW and IM value of system VPD.",
+                    "If anything gets changed in that combination, then it can't determine",
+                    "the appropriate DTB for that system. Need to check HW and IM keywords."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.GPIOError",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4007",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation": {
+                "Description": "GPIO line error",
+                "Message": "GPIO line couldn't be found or read.",
+                "Notes": [
+                    "The BMC could not access a GPIO line. This generally means that the",
+                    " hardware had issues toggling the line and/or the device driver has",
+                    " not exposed the GPIO line to userspace due to underlying I2C issues.",
+                    " The I2C path will be called out."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Host.Boot.Error.WatchdogTimeout",
+            "Subsystem": "cec_sp_hostboot_iface",
+
+            "SRC":
+            {
+                "ReasonCode": "0xC101",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Host did not respond within the watchdog timeout interval",
+                "Message": "Host did not respond before the watchdog timeout interval expired",
+                "Notes": [
+                    "Host did not respond before the expiry of the watchdog timeout interval.",
+                    "Collecting hostboot dump."
+                ]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Version.Error.Incompatible",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3601",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "A system component has a software version that is incompatible.",
+                "Message": "A system component has a software version that is incompatible."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Version.Error.AlreadyExists",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3602",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "This image version already exists on the device.",
+                "Message": "This image version already exists on the device."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Image.Error.UnTarFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3603",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "An error occurred during untar.",
+                "Message": "An error occurred during untar."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Image.Error.ManifestFileFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3604",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "An error when reading the Manifest file..",
+                "Message": "An error when reading the Manifest file.."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Image.Error.InternalFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3605",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "The operation failed internally during processing the image.",
+                "Message": "The operation failed internally during processing the image."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Image.Error.ImageFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3606",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "An error occurred processing the image.",
+                "Message": "An error occurred processing the image."
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Software.Image.Error.BusyFailure",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3600",
+            "SRC":
+            {
+                "ReasonCode": "0x3607",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "The device is busy during the update.",
+                "Message": "The device is busy during the update."
+            }
+        }
+
+    ]
+}

--- a/modules/pel/peltool/parse_user_data.py
+++ b/modules/pel/peltool/parse_user_data.py
@@ -1,0 +1,96 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import creatorIDs
+from pel.hexdump import hexdump
+from enum import Enum, unique
+import json
+import sys
+
+
+@unique
+class UserDataFormat(Enum):
+    json = 0x1
+    cbor = 0x2
+    text = 0x3
+    custom = 0x4
+
+
+def get_value(data: memoryview, start: int, end: int) -> int:
+    return int.from_bytes(data[start: start + end], byteorder="big")
+
+
+class ParseUserData:
+    """
+    The toJSON() function handles parsing the data from either UserData or
+    ExtUserData sections.
+    """
+
+    def __init__(self, creatorID: str, compID: str, subType: int, version: int,
+                 data: bytes):
+        self.creatorID = creatorID
+        self.compID = compID
+        self.subType = subType
+        self.version = version
+        self.data = data
+
+    def parse(self) -> str:
+        if self.creatorID in creatorIDs and creatorIDs[self.creatorID] == "BMC" \
+                and self.compID == 0x2000:
+            value = self.getBuiltinFormatJSON()
+        else:
+            value = self.parseCustom()
+
+        return value
+
+    def parseCustom(self) -> str:
+        import importlib
+        name = (self.creatorID.lower() + "%04X" % self.compID).lower()
+        try:
+            cls = importlib.import_module("udparsers." + name + "." + name)
+            mv = memoryview(self.data)
+            return cls.parseUDToJson(self.subType, self.version, mv)
+        except ImportError:
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+        except Exception as e:
+            print('Failed parsing user data for creator {} compID {} '
+                  'subType {} version {}: {}'.format(
+                      self.creatorID, "0x%04X" % self.compID,
+                      "0x%X" % self.subType, self.version, str(e)), file=sys.stderr)
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+
+    def getBuiltinFormatJSON(self) -> str:
+        if self.subType == UserDataFormat.json.value:
+            string = bytes.decode(self.data).strip().rstrip('\x00')
+            return string
+        elif self.subType == UserDataFormat.cbor.value:
+            # TODO, support CBOR (binary JSON)
+            # pad = get_value(self.stream.data, self.dataLength - 4, 4)
+            # if self.dataLength > pad + 4:
+            #     self.dataLength = self.dataLength - pad - 4
+            # out.update(json.loads(bytes.decode(
+            #     self.stream.get_mem(self.dataLength)).strip()))
+
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+
+        elif self.subType == UserDataFormat.text.value:
+            lines = []
+            line = ''
+            for ch in bytes.decode(self.data).strip().rstrip('\x00'):
+                if ch != '\n':
+                    if ord(ch) < ord(' ') or ord(ch) > ord('~'):
+                        ch = '.'
+                    line += ch
+                else:
+                    lines.append(line)
+                    line = ''
+
+            if line != '':
+                lines.append(line)
+
+            return json.dumps(lines)
+        else:
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))

--- a/modules/pel/peltool/pel_types.py
+++ b/modules/pel/peltool/pel_types.py
@@ -1,0 +1,37 @@
+from enum import Enum, unique
+
+
+@unique
+class TransmissionState(Enum):
+    newPEL = 0
+    badPEL = 1
+    sent = 2
+    acked = 3
+
+
+@unique
+class SectionID(Enum):
+    privateHeader = 0x5048         # 'PH'
+    userHeader = 0x5548            # 'UH'
+    primarySRC = 0x5053            # 'PS'
+    secondarySRC = 0x5353          # 'SS'
+    extendedUserHeader = 0x4548    # 'EH'
+    failingMTMS = 0x4D54           # 'MT'
+    dumpLocation = 0x4448          # 'DH'
+    firmwareError = 0x5357         # 'SW'
+    impactedPart = 0x4C50          # 'LP'
+    logicalResource = 0x4C52       # 'LR'
+    hmcID = 0x484D                 # 'HM'
+    epow = 0x4550                  # 'EP'
+    ioEvent = 0x4945               # 'IE'
+    mfgInfo = 0x4D49               # 'MI'
+    callhome = 0x4348              # 'CH'
+    userData = 0x5544              # 'UD'
+    envInfo = 0x4549               # 'EI'
+    extUserData = 0x4544           # 'ED'
+
+
+@unique
+class SRCType(Enum):
+    bmcError = "BD"
+    powerError = "11"

--- a/modules/pel/peltool/pel_values.py
+++ b/modules/pel/peltool/pel_values.py
@@ -1,0 +1,233 @@
+from pel.peltool.pel_types import TransmissionState
+
+"""
+Creator IDs
+"""
+creatorIDs = {"B": "Hostboot", "C": "HMC", "H": "PHYP", "K": "Sapphire",
+              "L": "Partition FW", "M": "I/O Drawer", "O": "BMC",
+              "P": "PowerNV", "S": "SLIC",  "T": "OCC"}
+
+"""
+Section Names
+"""
+sectionNames = {
+    "PH": "Private Header",
+    "UH": "User Header",
+    "PS": "Primary SRC",
+    "SS": "Secondary SRC",
+    "EH": "Extended User Header",
+    "MT": "Failing MTMS",
+    "DH": "Dump Location",
+    "SW": "Firmware Error",
+    "LP": "Impacted Partition",
+    "LR": "Logical Resource",
+    "HM": "HMC ID",
+    "EP": "EPOW",
+    "IE": "IO Event",
+    "MI": "MFG Info",
+    "CH": "Call Home",
+    "UD": "User Data",
+    "EI": "Env Info",
+    "ED": "Extended User Data"}
+
+"""
+The possible values for the subsystem field  in the User Header.
+"""
+subsystemValues = {
+    0x10: "Processor",
+    0x11: "Processor FRU",
+    0x12: "Processor Chip Cache",
+    0x13: "Processor Unit (CPU)",
+    0x14: "Processor Bus Controller",
+
+    0x20: "Memory ",
+    0x21: "Memory Controller",
+    0x22: "Memory Bus Interface",
+    0x23: "Memory DIMM",
+    0x24: "Memory Card/FRU",
+    0x25: "External Cache",
+
+    0x30: "I/O",
+    0x31: "I/O Hub",
+    0x32: "I/O Bridge",
+    0x33: "I/O bus interface",
+    0x34: "I/O Processor",
+    0x35: "SMA Hub",
+    0x38: "PCI Bridge Chip",
+
+    0x40: "I/O Adapter",
+    0x41: "I/O Adapter Communication",
+    0x46: "I/O Device",
+    0x47: "I/O Device Disk",
+    0x4C: "I/O External Peripheral",
+    0x4D: "I/O External Peripheral Local Work Station",
+    0x4E: "I/O Storage Mezza Expansion",
+
+    0x50: "CEC Hardware",
+    0x51: "CEC Hardware - Service Processor A",
+    0x52: "CEC Hardware - Service Processor B",
+    0x53: "CEC Hardware - Node Controller",
+    0x55: "CEC Hardware - VPD Interface",
+    0x56: "CEC Hardware - I2C Devices",
+    0x57: "CEC Hardware - CEC Chip Interface",
+    0x58: "CEC Hardware - Clock",
+    0x59: "CEC Hardware - Operator Panel",
+    0x5A: "CEC Hardware - Time-Of-Day Hardware",
+    0x5B: "CEC Hardware - Memory Device",
+    0x5C: "CEC Hardware - Hypervisor<->Service Processor Interface",
+    0x5D: "CEC Hardware - Service Network",
+    0x5E: "CEC Hardware - Hostboot-Service Processor Interface",
+
+    0x60: "Power/Cooling",
+    0x61: "Power Supply",
+    0x62: "Power Control Hardware",
+    0x63: "Fan (AMD)",
+    0x64: "Digital Power Supply",
+
+    0x70: "Miscellaneous",
+    0x71: "HMC & Hardware",
+    0x72: "Test Tool",
+    0x73: "Removable Media",
+    0x74: "Multiple Subsystems",
+    0x75: "Not Applicable",
+    0x76: "Miscellaneous",
+
+    0x7A: "Hypervisor lost communication with service processor",
+    0x7B: "Service processor lost communication with Hypervisor",
+    0x7C: "Service processor lost communication with HMC",
+    0x7D: "HMC lost communication with logical partition",
+    0x7E: "HMC lost communication with BPA",
+    0x7F: "HMC lost communication with another HMC",
+
+    0x80: "Platform Firmware",
+    0x81: "Service Processor Firmware",
+    0x82: "System Hypervisor Firmware",
+    0x83: "Partition Firmware",
+    0x84: "SLIC Firmware",
+    0x85: "System Power Control Network Firmware",
+    0x86: "Bulk Power Firmware Side A",
+    0x87: "HMC Code",
+    0x88: "Bulk Power Firmware Side B",
+    0x89: "Virtual Service Processor Firmware",
+    0x8A: "HostBoot",
+    0x8B: "OCC",
+    0x8D: "BMC Firmware",
+
+    0x90: "Software",
+    0x91: "Operating System software",
+    0x92: "XPF software",
+    0x93: "Application software",
+
+    0xA0: "External Environment",
+    0xA1: "Input Power Source (ac)",
+    0xA2: "Room Ambient Temperature",
+    0xA3: "User Error",
+    0xA4: "Corrosion"}
+
+
+"""
+The possible values for the Event Scope field in the User Header.
+"""
+eventScopeValues = {
+    0x01: "Single Partition",
+    0x02: "Multiple Partitions",
+    0x03: "Entire Platform",
+    0x04: "Multiple Platforms"}
+
+
+"""
+The possible values for the Event Type field in the User Header.
+"""
+eventTypeValues = {
+    0x00: "Not Applicable",
+    0x01: "Miscellaneous, Informational Only",
+    0x02: "Tracing Event",
+    0x08: "Dump Notification",
+    0x30: "Customer environmental problem back to normal"}
+
+
+"""
+The possible values for the severity field in the User Header.
+"""
+severityValues = {
+    0x00: "Informational Event",
+
+    0x10: "Recovered Error",
+    0x20: "Predictive Error",
+    0x21: "Predictive Error, Degraded Performance",
+    0x22: "Predictive Error, Correctable",
+    0x23: "Predictive Error, Correctable, Degraded",
+    0x24: "Predictive Error, Redundancy Lost",
+
+    0x40: "Unrecoverable Error",
+    0x41: "Unrecoverable Error, Degraded Performance",
+    0x44: "Unrecoverable Error, Loss of Redundancy",
+    0x45: "Unrecoverable, Loss of Redundancy + Performance",
+    0x48: "Unrecoverable Error, Loss of Function",
+
+    0x50: "Critical Error, Scope of Failure unknown",
+    0x51: "Critical Error, System Termination",
+    0x52: "Critical Error, System Failure likely or imminent",
+    0x53: "Critical Error, Partition(s) Termination",
+    0x54: "Critical Error, Partition(s) Failure likely or imminent",
+
+    0x60: "Error detected during diagnostic test",
+    0x61: "Diagostic error, resource w/incorrect results",
+
+    0x71: "Symptom Recovered",
+    0x72: "Symptom Predictive",
+    0x74: "Symptom Unrecoverable",
+    0x75: "Symptom Critical",
+    0x76: "Symptom Diag Err"}
+
+
+"""
+The possible values for the Action Flags field in the User Header.
+"""
+actionFlagsValues = {
+    0x8000: "Service Action Required",
+    0x4000: "Event not customer viewable",
+    0x2000: "Report Externally",
+    0x1000: "Do Not Report To Hypervisor",
+    0x0800: "HMC Call Home",
+    0x0400: "Isolation Incomplete, further analysis required",
+    0x0100: "Service Processor Call Home Required"}
+
+"""
+Map for transmission states
+"""
+transmissionStates = {
+    TransmissionState.newPEL.value: "Not Sent",
+    TransmissionState.badPEL.value: "Rejected",
+    TransmissionState.sent.value: "Sent",
+    TransmissionState.acked.value: "Acked"}
+
+"""
+Map for Callout Failing Component Types
+"""
+failingComponentType = {
+    0x10: "Normal Hardware FRU",
+    0x20: "Code FRU",
+    0x30: "Configuration error, configuration procedure required",
+    0x40: "Maintenance Procedure Required",
+    0x90: "External FRU",
+    0xA0: "External Code FRU",
+    0xB0: "Tool FRU",
+    0xC0: "Symbolic FRU",
+    0xE0: "Symbolic FRU with trusted location code"}
+
+"""
+The possible values for the Callout Priority field in the SRC.
+"""
+calloutPriorityValues = {
+    0x48: "Mandatory, replace all with this type as a unit",
+    0x4D: "Medium Priority",
+    0x41: "Medium Priority A, replace these as a group",
+    0x42: "Medium Priority B, replace these as a group",
+    0x43: "Medium Priority C, replace these as a group",
+    0x4C: "Lowest priority replacement"}
+
+"""
+Map for Procedure Descriptions
+"""
+procedureDesc = {"TODO": "TODO"}

--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import os
+import json
+import argparse
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.private_header import PrivateHeader
+from pel.peltool.user_header import UserHeader
+from pel.peltool.src import SRC
+from pel.peltool.pel_types import SectionID
+from pel.peltool.extend_user_header import ExtendedUserHeader
+from pel.peltool.failing_mtms import FailingMTMS
+from pel.peltool.user_data import UserData
+from pel.peltool.ext_user_data import ExtUserData
+from pel.peltool.default import Default
+from pel.peltool.imp_partition import ImpactedPartition
+from pel.peltool.pel_values import sectionNames
+
+
+def getSectionName(sectionID: int) -> str:
+    id = chr((sectionID >> 8) & 0xFF) + chr(sectionID & 0xFF)
+    return sectionNames.get(id, 'Unknown')
+
+
+def parserHeader(stream: DataStream):
+    sectionID = stream.get_int(2)
+    sectionLen = stream.get_int(2)
+    versionID = stream.get_int(1)
+    subType = stream.get_int(1)
+    componentID = stream.get_int(2)
+    return sectionID, sectionLen, versionID, subType, componentID
+
+
+def generatePH(stream: DataStream, out: OrderedDict) -> (bool, PrivateHeader):
+    sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+        stream)
+    if sectionID != SectionID.privateHeader.value:
+        print("Failed to parser Private Header, section ID = %x" % (sectionID))
+        return False, None
+
+    ph = PrivateHeader(stream, sectionID, sectionLen,
+                       versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ph.toJSON()
+    return True, ph
+
+
+def generateUH(stream: DataStream, creatorID: str, out: OrderedDict) -> (bool, UserHeader):
+    sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+        stream)
+    if sectionID != SectionID.userHeader.value:
+        print("Failed to parser User Header, section ID = %d" % (sectionID))
+        return False, None
+
+    uh = UserHeader(stream, sectionID, sectionLen,
+                    versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = uh.toJSON()
+    return True, uh
+
+
+def generateSRC(stream: DataStream, out: OrderedDict,
+                sectionID: int, sectionLen: int, versionID: int, subType: int,
+                componentID: int, creatorID: str) -> (bool, SRC):
+    src = SRC(stream, sectionID, sectionLen,
+              versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = src.toJSON()
+    return True, src
+
+
+def generateEH(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, ExtendedUserHeader):
+    eh = ExtendedUserHeader(stream, sectionID, sectionLen,
+                            versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = eh.toJSON()
+    return True, eh
+
+
+def generateMT(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, FailingMTMS):
+    mt = FailingMTMS(stream, sectionID, sectionLen,
+                     versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = mt.toJSON()
+    return True, mt
+
+
+def generateED(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int) -> (bool, ExtUserData):
+    ed = ExtUserData(stream, sectionID, sectionLen,
+                     versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ed.toJSON()
+    return True, ed
+
+
+def generateUD(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, UserData):
+    ud = UserData(stream, sectionID, sectionLen, versionID,
+                  subType, componentID, creatorID)
+
+    out[getSectionName(sectionID)] = ud.toJSON()
+    return True, ud
+
+
+def generateIP(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, ExtUserData):
+    ip = ImpactedPartition(stream, sectionID, sectionLen,
+                           versionID, subType, componentID,
+                           creatorID)
+    out[getSectionName(sectionID)] = ip.toJSON()
+    return True, ip
+
+
+def generateDefault(stream: DataStream, out: OrderedDict, sectionID: int,
+                    sectionLen: int, versionID: int, subType: int,
+                    componentID: int) -> (bool, ExtUserData):
+    ed = Default(stream, sectionID, sectionLen,
+                 versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ed.toJSON()
+    return True, ed
+
+
+def sectionFun(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str):
+    if sectionID == SectionID.primarySRC.value or \
+            sectionID == SectionID.secondarySRC.value:
+        generateSRC(stream, out, sectionID, sectionLen,
+                    versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.extendedUserHeader.value:
+        generateEH(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.failingMTMS.value:
+        generateMT(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.extUserData.value:
+        generateED(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID)
+    elif sectionID == SectionID.userData.value:
+        generateUD(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.impactedPart.value:
+        generateIP(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    else:
+        generateDefault(stream, out, sectionID, sectionLen,
+                        versionID, subType, componentID)
+
+
+def buildOutput(sections: list, out: OrderedDict):
+    counts = {}
+
+    # Find the section names that appear more than once.
+    # counts[section name] = [# occurrences, counter]
+    for section_num in range(len(sections)):
+        name = list(sections[section_num].keys())[0]
+        if name not in counts:
+            counts[name] = [1, 0]
+        else:
+            counts[name] = [counts[name][0]+1, 0]
+
+    # For sections that appear more than once, add a
+    # ' <count>' to the name, eg 'User Data 1'.
+    for section_num in range(len(sections)):
+        name = list(sections[section_num].keys())[0]
+
+        if counts[name][0] == 1:
+            out[name] = sections[section_num][name]
+        else:
+            modifier = counts[name][1]
+            out[name + ' ' + str(modifier)] = sections[section_num][name]
+            counts[name][1] = modifier + 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PELTools")
+
+    parser.add_argument('-f', '--file', dest='file',
+                        help='input pel file to parse')
+    args = parser.parse_args()
+
+    with open(args.file, 'rb') as fd:
+        data = fd.read()
+        stream = DataStream(data, byte_order='big', is_signed=False)
+        out = OrderedDict()
+        ret, ph = generatePH(stream, out)
+        if ret == False:
+            return
+
+        ret, _ = generateUH(stream, ph.creatorID, out)
+        if ret == False:
+            return
+
+        section_jsons = []
+        for _ in range(2, ph.sectionCount):
+            sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+                stream)
+            section_json = {}
+            sectionFun(stream, section_json, sectionID, sectionLen,
+                       versionID, subType, componentID, ph.creatorID)
+            section_jsons.append(section_json)
+
+        buildOutput(section_jsons, out)
+
+        print(json.dumps(out, indent=4))
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/pel/peltool/private_header.py
+++ b/modules/pel/peltool/private_header.py
@@ -1,0 +1,75 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import creatorIDs
+from pel.peltool.comp_id import getDisplayCompID
+
+
+def getTimestamp(stream: DataStream) -> str:
+    year = stream.get_mem(2).hex()
+    month = stream.get_mem(1).hex()
+    day = stream.get_mem(1).hex()
+    hour = stream.get_mem(1).hex()
+    min = stream.get_mem(1).hex()
+    sec = stream.get_mem(1).hex()
+    hundredths = stream.get_mem(1).hex()
+    #  "03/08/2022 18:40:27"
+    createTime = month + "/" + day + "/" + year + " " + hour + ":" + min + ":" + sec
+    return createTime
+
+
+class PrivateHeader:
+    """
+    This represents the Private Header section in a PEL.  It is required,
+    and it is always the first section.
+
+    The Section base class handles the section header structure that every
+    PEL section has at offset zero.
+
+    The fields in this class directly correspond to the order and sizes of
+    the fields in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.reserved0 = 0
+        self.reserved1 = 0
+        self.subType = subType
+        self.componentID = componentID
+        self.sectionCount = 0
+        self.creatorID = ""
+        self.obmcLogID = 0
+        self.creatorVersion = 0
+        self.pLID = ""
+        self.lEID = ""
+        self.createTime = ""
+        self.committeTime = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.createTime = getTimestamp(self.stream)
+        self.committeTime = getTimestamp(self.stream)
+        self.creatorID = bytes.decode(self.stream.get_mem(1))
+        self.reserved0 = self.stream.get_int(1)
+        self.reserved1 = self.stream.get_int(1)
+        self.sectionCount = self.stream.get_int(1)
+        self.obmcLogID = self.stream.get_int(4)
+        self.creatorVersion = "0x{:02X}".format(self.stream.get_int(8))
+        self.pLID = "0x{:02X}".format(self.stream.get_int(4))
+        self.lEID = "0x{:02X}".format(self.stream.get_int(4))
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Created at"] = self.createTime
+        out["Committed at"] = self.committeTime
+        out["Creator Subsystem"] = creatorIDs.get(self.creatorID, 'Unknown')
+        out["CSSVER"] = self.creatorVersion
+        out["Platform Log Id"] = self.pLID
+        out["Entry Id"] = self.lEID
+        out["BMC Event Log Id"] = str(self.obmcLogID)
+
+        return out

--- a/modules/pel/peltool/registry.py
+++ b/modules/pel/peltool/registry.py
@@ -1,0 +1,53 @@
+import json
+import os
+
+
+class Registry:
+    def __init__(self):
+        try:
+            import pel_registry
+            path = pel_registry.get_registry_path()
+        except ModuleNotFoundError:
+            # On the BMC, pel_registry isn't available, so just
+            # use the known location.
+            path = \
+                '/usr/share/phosphor-logging/pels/message_registry.json'
+            if not os.path.exists(path):
+                path = ''
+
+        if path:
+            self.pels = self.loadJson(path)
+        else:
+            self.pels = []
+
+    def loadJson(self, path: str):
+        with open(path, "r") as f:
+            load_dict = json.load(f)
+            return load_dict["PELs"]
+
+    def getErrorMessage(self, code: str, srcType: str) -> dict:
+        output = {}
+
+        for pel in self.pels:
+            if "ReasonCode" not in pel["SRC"]:
+                continue
+
+            entryType = pel["SRC"].get("Type", "BD")
+            if srcType != entryType:
+                continue
+
+            if code not in pel["SRC"]["ReasonCode"]:
+                continue
+
+            output['Message'] = pel['Documentation']['Message']
+
+            if ('MessageArgSources' in pel['Documentation']):
+                output['MessageArgSources'] = \
+                    pel['Documentation']['MessageArgSources']
+
+            if 'Words6To9' in pel['SRC'] and pel['SRC']['Words6To9']:
+                output['Words6To9'] = pel['SRC']['Words6To9']
+
+            return output
+
+        return output

--- a/modules/pel/peltool/src.py
+++ b/modules/pel/peltool/src.py
@@ -1,0 +1,347 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from enum import Enum, unique
+from pel.peltool.pel_types import SRCType
+from pel.peltool.registry import Registry
+from pel.peltool.pel_values import failingComponentType, \
+    calloutPriorityValues, procedureDesc
+from pel.peltool.comp_id import getDisplayCompID
+import json
+import sys
+
+
+@unique
+class HeaderFlags(Enum):
+    additionalSections = 0x01
+    powerFaultEvent = 0x02
+    hypDumpInit = 0x04
+    postOPPanel = 0x08
+    i5OSServiceEventBit = 0x10
+    virtualProgressSRC = 0x80
+
+
+@unique
+class ErrorStatusFlags(Enum):
+    terminateFwErr = 0x20000000
+    deconfigured = 0x02000000
+    guarded = 0x01000000
+
+
+@unique
+class Flags(Enum):
+    pnSupplied = 0x08
+    ccinSupplied = 0x04
+    maintProcSupplied = 0x02
+    snSupplied = 0x01
+
+
+def get_value(data: memoryview, start: int, end: int) -> int:
+    return int.from_bytes(data[start: start + end], byteorder="big")
+
+
+class FRUIdentity:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.size = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.pnOrProcedureID = ""
+        self.ccin = ""
+        self.sn = ""
+        self.flattenedSize = 4
+
+        if self.flags & Flags.pnSupplied.value or self.flags & Flags.maintProcSupplied.value:
+            self.pnOrProcedureID = bytes.decode(
+                stream.get_mem(8)).strip("\u0000")
+            self.flattenedSize += 8
+
+        if self.flags & Flags.ccinSupplied.value:
+            self.ccin = bytes.decode(stream.get_mem(4)).strip("\u0000")
+            self.flattenedSize += 4
+
+        if self.flags & Flags.snSupplied.value:
+            self.sn = bytes.decode(stream.get_mem(12)).strip("\u0000")
+            self.flattenedSize += 12
+
+
+class PCEIdentity:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.flattenedSize = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.machineType = bytes.decode(stream.get_mem(8)).strip("\u0000")
+        self.serialNumber = bytes.decode(
+            stream.get_mem(12)).strip("\u0000")
+        if self.flattenedSize < (4 + 8 + 12):
+            print("PCE identity structure size field too small")
+            return
+        self.pceNameSize = self.flattenedSize - (4 + 8 + 12)
+        self.pceName = bytes.decode(
+            stream.get_mem(self.pceNameSize)).strip("\u0000")
+
+
+class MRUCallout:
+    def __init__(self, priority: int, id: int) -> None:
+        self.priority = priority
+        self.id = id
+
+
+class MRU:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.flattenedSize = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.reserved4B = stream.get_int(4)
+        self.mrus = []
+        for _ in range(self.flags & 0xf):
+            mru = MRUCallout(stream.get_int(4), stream.get_int(4))
+            self.mrus.append(mru)
+
+
+class Callout:
+    def __init__(self, stream: DataStream):
+        self.size = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.priority = stream.get_int(1)
+        self.locationCode = ""
+        self.locationCodeSize = stream.get_int(1)
+        if self.locationCodeSize > 0:
+            self.locationCode = bytes.decode(
+                stream.get_mem(self.locationCodeSize)).strip("\u0000")
+        self.fruIdentity = None
+        self.pceIdentity = None
+        self.mru = None
+
+        currentSize = 4 + self.locationCodeSize
+        while self.size > currentSize:
+            type = get_value(stream.data, stream.index, 2)
+            if type == 0x4944:
+                self.fruIdentity = FRUIdentity(stream)
+            elif type == 0x5045:
+                self.pceIdentity = PCEIdentity(stream)
+            elif type == 0x4D52:
+                self.mru = MRU(stream)
+            else:
+                break
+
+    def flattenedSize(self):
+        size = 4 + self.locationCodeSize
+        size += self.fruIdentity.flattenedSize if self.fruIdentity else 0
+        size += self.pceIdentity.flattenedSize if self.pceIdentity else 0
+        size += self.mru.flattenedSize if self.mru else 0
+        return size
+
+
+class SRC:
+    """
+    SRC stands for System Reference Code.
+
+    This class represents the SRC sections in the PEL, of which there are 2:
+    primary SRC and secondary SRC.  These are the same structurally, the
+    difference is that the primary SRC must be the 3rd section in the PEL if
+    present and there is only one of them, and the secondary SRC sections are
+    optional and there can be more than one (by definition, for there to be a
+    secondary SRC, a primary SRC must also exist).
+
+    This section consists of:
+    - An 8B header (Has the version, flags, hexdata word count, and size fields)
+    - 8 4B words of hex data
+    - An ASCII character string
+    - An optional subsection for Callouts
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.version = 0
+        self.flags = 0
+        self.reserved1B = 0
+        self.wordCount = 0
+        self.reserved2B = 0
+        self.size = 0
+        self.hexData = []
+        self.srcType = 0
+        self.asciiString = ""
+
+    def buildMessage(self, details: dict) -> str:
+        if 'Message' not in details:
+            return ''
+
+        message = details['Message']
+        if 'MessageArgSources' in details:
+            hexword_args = []
+
+            # Strip off the word number from SRCWordN and subtract 2 to get
+            # the hexData word to use
+            for arg in details['MessageArgSources']:
+                hexword_args.append(hex(self.hexData[int(arg[-1]) - 2]))
+
+            # message may have %1, etc. replace with {} and then fill
+            # those in with the hexData words
+            import re
+            message = re.sub(r'%[1-9]', "{}", message)
+            message = message.format(*hexword_args)
+
+        return message
+
+    def buildHexwordDescs(self, details: dict) -> OrderedDict:
+        descriptions = OrderedDict()
+        if 'Words6To9' not in details or not details['Words6To9']:
+            return
+
+        for num, word_contents in details['Words6To9'].items():
+            # Nobody wants to see these if no description
+            if 'Description' not in word_contents:
+                continue
+
+            index = int(num) - 2
+            descriptions[word_contents['AdditionalDataPropSource']] = \
+                [self.hexData[index], word_contents['Description']]
+
+        return descriptions
+
+    def getErrorDetails(self, out: OrderedDict, code: str, srcType: str):
+        code = "0x" + code
+        registry = Registry()
+        details = registry.getErrorMessage(code, srcType)
+
+        od = OrderedDict()
+        od["Message"] = self.buildMessage(details)
+        if od["Message"]:
+            descs = self.buildHexwordDescs(details)
+            if descs:
+                od.update(descs)
+
+            out["Error Details"] = od
+
+    def getCallouts(self, out: OrderedDict):
+        od = OrderedDict()
+        _ = self.stream.get_int(1)  # subsectionID
+        _ = self.stream.get_int(1)  # subsectionFlags
+        subsectionWordLength = self.stream.get_int(2)
+        currentLength = 4
+        callouts = []
+        while subsectionWordLength * 4 > currentLength:
+            callout = Callout(self.stream)
+            callouts.append(callout)
+            currentLength += callout.flattenedSize()
+        od["Callout Count"] = len(callouts)
+        calloutJsons = []
+        for callout in callouts:
+            json = OrderedDict()
+            if callout.fruIdentity:
+                json["FRU Type"] = \
+                    failingComponentType.get(callout.fruIdentity.flags & 0xf0,
+                                             'Invalid')
+                json["Priority"] = calloutPriorityValues.get(
+                    callout.priority, 'Invalid')
+                if len(callout.locationCode) > 0:
+                    json["Location Code"] = callout.locationCode
+                if callout.fruIdentity.flags & Flags.pnSupplied.value:
+                    json["Part Number"] = callout.fruIdentity.pnOrProcedureID
+                if callout.fruIdentity.flags & Flags.maintProcSupplied.value:
+                    json["Procedure"] = callout.fruIdentity.pnOrProcedureID
+                    if callout.fruIdentity.pnOrProcedureID in procedureDesc:
+                        json["Description"] = \
+                            procedureDesc[callout.fruIdentity.pnOrProcedureID]
+                if callout.fruIdentity.flags & Flags.ccinSupplied.value:
+                    json["CCIN"] = callout.fruIdentity.ccin
+                if callout.fruIdentity.flags & Flags.snSupplied.value:
+                    json["Serial Number"] = callout.fruIdentity.sn
+
+            if callout.pceIdentity:
+                if len(callout.pceIdentity.machineType) > 0:
+                    json["PCE MTMS"] = callout.pceIdentity.machineType + \
+                        "_" + callout.pceIdentity.serialNumber
+                if len(callout.pceIdentity.pceName):
+                    json["PCE Name"] = callout.pceIdentity.pceName
+
+            if callout.mru:
+                mru = OrderedDict()
+                mruId = ""
+                for mru in callout.mru.mrus:
+                    mruId += "%08X" % mru.id + ","
+                json["MRU Id"] = mruId[:-1]
+
+            calloutJsons.append(json)
+        od["Callouts"] = calloutJsons
+        out["Callout Section"] = od
+
+    def parse(self, hexwords: list) -> str:
+        if len(hexwords) < 8:
+            print("The length of the hexwords < 8, exit")
+            exit(1)
+
+        name = self.creatorID.lower() + "src"
+        try:
+            import importlib
+            cls = importlib.import_module("srcparsers." + name + "." + name)
+        except:
+            return ""
+
+        try:
+            return cls.parseSRCToJson(self.asciiString, hexwords[0], hexwords[1], hexwords[2],
+                                      hexwords[3], hexwords[4], hexwords[5], hexwords[6], hexwords[7])
+        except Exception as e:
+            print('Error getting SRC details for {}: {}'.format(
+                self.asciiString.rstrip(), str(e)), file=sys.stderr)
+            return ''
+
+    def toJSON(self) -> OrderedDict:
+        self.version = "0x" + self.stream.get_mem(1).hex()
+        self.flags = self.stream.get_int(1)
+        self.reserved1B = self.stream.get_int(1)
+        self.wordCount = self.stream.get_int(1)
+        self.reserved2B = self.stream.get_int(2)
+        self.size = self.stream.get_int(2)
+        for i in range(8):
+            self.hexData.append(self.stream.get_int(4))
+        self.asciiString = bytes.decode(self.stream.get_mem(32))
+        self.srcType = self.asciiString[0:2]
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["SRC Version"] = self.version
+        out["SRC Format"] = "0x{:02X}".format(self.hexData[0] & 0xFF)
+        out["Virtual Progress SRC"] = "True" if self.flags & HeaderFlags.virtualProgressSRC.value else "False"
+        out["I5/OS Service Event Bit"] = "True" if self.flags & HeaderFlags.i5OSServiceEventBit.value else "False"
+        out["Hypervisor Dump Initiated"] = "True" if self.flags & HeaderFlags.hypDumpInit.value else "False"
+        if self.srcType == SRCType.bmcError.value or self.srcType == SRCType.powerError.value:
+            out["Backplane CCIN"] = str("%04X" % (self.hexData[1] >> 16))
+            out["Terminate FW Error"] = "True" if self.hexData[3] & ErrorStatusFlags.terminateFwErr.value else "False"
+            out["Deconfigured"] = "True" if self.hexData[3] & ErrorStatusFlags.deconfigured.value else "False"
+            out["Guarded"] = "True" if self.hexData[3] & ErrorStatusFlags.guarded.value else "False"
+            self.getErrorDetails(
+                out, self.asciiString[4:8], self.asciiString[0:2])
+
+        out["Valid Word Count"] = "0x" + "%02X" % self.wordCount
+        out["Reference Code"] = self.asciiString.strip()
+
+        hexwords = []
+        for i in range(2, self.wordCount + 1):
+            num = i
+            if num >= 2 and num <= 9:
+                num -= 2
+            tmpWord = "%08X" % self.hexData[num]
+            out["Hex Word " + str(i)] = tmpWord
+            hexwords.append(tmpWord)
+
+        # add zeroes to get 8 hexwords for parse()
+        while len(hexwords) < 8:
+            hexwords.append('00000000')
+
+        if self.flags & HeaderFlags.additionalSections.value:
+            self.getCallouts(out)
+
+        value = self.parse(hexwords)
+        if value != '' and value != 'null':
+            out["SRC Details"] = json.loads(value)
+
+        return out

--- a/modules/pel/peltool/user_data.py
+++ b/modules/pel/peltool/user_data.py
@@ -1,0 +1,46 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+import json
+from pel.peltool.parse_user_data import ParseUserData
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class UserData:
+    """
+    This represents the User Data section in a PEL.  It is free form data
+    that the creator knows the contents of.  The component ID, version,
+    and sub-type fields in the section header are used to identify the
+    format.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.dataLength = sectionLen - 8
+        self.data = self.stream.get_mem(self.dataLength)
+
+    def toJSON(self) -> OrderedDict:
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        parser = ParseUserData(self.creatorID, self.componentID, self.subType,
+                               self.versionID, self.data)
+
+        value = parser.parse()
+
+        j = json.loads(value)
+        if not isinstance(j, dict):
+            out['Data'] = j
+        else:
+            out.update(j)
+
+        return out

--- a/modules/pel/peltool/user_header.py
+++ b/modules/pel/peltool/user_header.py
@@ -1,0 +1,70 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import actionFlagsValues, subsystemValues, \
+    severityValues, eventTypeValues, eventScopeValues, transmissionStates
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class UserHeader:
+    """
+    This represents the Private Header section in a PEL.  It is required,
+    and it is always the second section.
+
+    The Section base class handles the section header structure that every
+    PEL section has at offset zero.
+
+    The fields in this class directly correspond to the order and sizes of
+    the fields in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.eventSubsystem = 0
+        self.eventScope = 0
+        self.eventSeverity = 0
+        self.eventType = 0
+        self.reserved4Byte1 = 0
+        self.problemDomain = 0
+        self.problemVector = 0
+        self.actionFlags = 0
+        self.states = 0
+
+    def toJSON(self) -> OrderedDict:
+        self.eventSubsystem = self.stream.get_int(1)
+        self.eventScope = self.stream.get_int(1)
+        self.eventSeverity = self.stream.get_int(1)
+        self.eventType = self.stream.get_int(1)
+        self.reserved4Byte1 = self.stream.get_int(4)
+        self.problemDomain = self.stream.get_int(1)
+        self.problemVector = self.stream.get_int(1)
+        self.actionFlags = self.stream.get_int(2)
+        self.states = self.stream.get_int(4)
+
+        list = []
+        for key in actionFlagsValues:
+            if key & self.actionFlags:
+                list.append(actionFlagsValues[key])
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Log Committed by"] = getDisplayCompID(
+            self.componentID, self.creatorID)
+        out["Subsystem"] = subsystemValues.get(self.eventSubsystem, 'Invalid')
+        out["Event Scope"] = eventScopeValues.get(self.eventScope, 'Invalid')
+        out["Event Severity"] = severityValues.get(self.eventSeverity, 'Invalid')
+        out["Event Type"] = eventTypeValues.get(self.eventType, 'Invalid')
+        out["Action Flags"] = list
+        out["Host Transmission"] = transmissionStates.get(
+            self.states & 0xff, 'Unknown')
+        out["HMC Transmission"] = transmissionStates.get(
+            (self.states & 0x0000FF00) >> 8, 'Unknown')
+
+        return out

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 
 setup(
     name        = "openpower-pel-parsers",
-    version     = "0.1",
+    version     = "1.0",
     classifiers = [ "License :: OSI Approved :: Apache Software License" ],
     packages    = find_packages("modules"),
-    package_dir = { "": "modules" },
+    package_dir = { "": "modules" }
 )


### PR DESCRIPTION
Provide a python version of peltool that can decode PELs given a raw pel file.
`python3 -m pel.peltool.peltool -f <file>`

This is multiplatform, the main targets for it being non-BMC tool platforms, though it will also work on the BMC.