### PR TITLE
Add peltool

### DIFF
--- a/modules/pel/datastream.py
+++ b/modules/pel/datastream.py
@@ -41,7 +41,7 @@ class DataStream:
         current index.
         """
         assert self.check_range(num_bytes), "range check failure"
-        o_mv = self.data[self.index : self.index + num_bytes]
+        o_mv = self.data[self.index: self.index + num_bytes]
         self.inc_index(num_bytes)
         return o_mv
 
@@ -65,5 +65,4 @@ class DataStream:
         assert None != is_signed,  "is_signed not defined"
 
         return int.from_bytes(self.get_mem(num_bytes),
-                              byteorder = byte_order, signed = is_signed)
-
+                              byteorder=byte_order, signed=is_signed)

--- a/modules/pel/peltool/comp_id.py
+++ b/modules/pel/peltool/comp_id.py
@@ -1,0 +1,52 @@
+from pel.peltool.pel_values import creatorIDs
+import os
+import json
+
+componentIDs = {}
+
+
+def getCompIDFilePath(creatorID: str) -> str:
+    """
+    Returns the file path to look up the component ID in.
+    The pel_registry module isn't available on the BMC,
+    so just look in /usr/share/... if that module isn't present.
+    """
+    try:
+        import pel_registry
+        file = pel_registry.get_comp_id_file_path(creatorID)
+    except ModuleNotFoundError:
+        # Use the BMC path
+        basePath = '/usr/share/phosphor-logging/pels/'
+        name = creatorID + '_component_ids.json'
+        file = os.path.join(os.path.join(basePath, name))
+
+    return file
+
+
+def getDisplayCompID(componentID: int, creatorID: str) -> str:
+    """
+    Converts a component ID to a name if possible for display.
+    Otherwise it returns the comp id like "0xFFFF"
+    """
+
+    # PHYP's IDs are ASCII
+    if creatorID in creatorIDs and creatorIDs[creatorID] == "PHYP":
+        first = (componentID >> 8) & 0xFF
+        second = componentID & 0xFF
+        if first != 0 and second != 0:
+            return chr(first) + chr(second)
+
+        return "{:04X}".format(componentID)
+
+    # try the comp IDs file named after the creator ID
+    if creatorID not in componentIDs:
+        compIDFile = getCompIDFilePath(creatorID)
+        if os.path.exists(compIDFile):
+            with open(compIDFile, 'r') as file:
+                componentIDs[creatorID] = json.load(file)
+
+    compIDStr = '{:04X}'.format(componentID).upper()
+    if creatorID in componentIDs and compIDStr in componentIDs[creatorID]:
+        return componentIDs[creatorID][compIDStr]
+
+    return "{:04X}".format(componentID)

--- a/modules/pel/peltool/default.py
+++ b/modules/pel/peltool/default.py
@@ -1,0 +1,34 @@
+from pel.datastream import DataStream
+from pel.hexdump import hexdump
+from collections import OrderedDict
+import json
+
+
+class Default:
+    """
+    This represents a section in a PEL that isn't handled by another class.
+    The toJSON function will just hexdump the contents.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.dataLength = sectionLen - 8
+        self.data = self.stream.get_mem(self.dataLength)
+
+    def toJSON(self) -> OrderedDict:
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = "0x{:02X}".format(self.componentID)
+
+        mv = memoryview(self.data)
+        out['Data'] = hexdump(mv)
+
+        return out

--- a/modules/pel/peltool/ext_user_data.py
+++ b/modules/pel/peltool/ext_user_data.py
@@ -1,0 +1,49 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.parse_user_data import ParseUserData
+from pel.peltool.comp_id import getDisplayCompID
+import json
+
+
+class ExtUserData:
+    """
+    This represents the Extended User Data section in a PEL.  It is free form
+    data that the creator knows the contents of.  The component ID, version, and
+    sub-type fields in the section header are used to identify the format.
+
+    This section is used for one subsystem to add FFDC data to a PEL created
+    by another subsystem.  It is basically the same as a UserData section,
+    except it has the creator ID of the section creator stored in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        dataLength = sectionLen - 4 - 8
+        self.creatorID = chr(stream.get_int(1))
+        self.reserved1B = stream.get_int(1)
+        self.reserved2B = stream.get_int(2)
+        self.data = stream.get_mem(dataLength)
+
+    def toJSON(self) -> OrderedDict:
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        parser = ParseUserData(self.creatorID, self.componentID, self.subType,
+                               self.versionID, self.data)
+
+        value = parser.parse()
+
+        j = json.loads(value)
+        if not isinstance(j, dict):
+            out['Data'] = j
+        else:
+            out.update(j)
+
+        return out

--- a/modules/pel/peltool/extend_user_header.py
+++ b/modules/pel/peltool/extend_user_header.py
@@ -1,0 +1,64 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.private_header import getTimestamp
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class ExtendedUserHeader:
+    """
+    This represents the Extended User Header section in a PEL.  It is  a required
+    section.  It contains code versions, an MTMS subsection, and a string called
+    a symptom ID.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.machineType = ""
+        self.serialNumber = ""
+        self.serverFWVersion = ""
+        self.subsystemFWVersion = ""
+        self.reserved4B = 0
+        self.refTime = ""
+        self.reserved1B1 = 0
+        self.reserved1B2 = 0
+        self.reserved1B3 = 0
+        self.symptomIDSize = ""
+        self.symptomID = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.machineType = bytes.decode(self.stream.get_mem(8))
+        self.serialNumber = bytes.decode(self.stream.get_mem(12))
+        self.serverFWVersion = bytes.decode(self.stream.get_mem(16))
+        self.subsystemFWVersion = bytes.decode(self.stream.get_mem(16))
+        self.reserved4B = self.stream.get_int(4)
+        self.refTime = getTimestamp(self.stream)
+        self.reserved1B1 = self.stream.get_int(1)
+        self.reserved1B2 = self.stream.get_int(1)
+        self.reserved1B3 = self.stream.get_int(1)
+        self.symptomIDSize = self.stream.get_int(1)
+        if self.symptomIDSize != 0:
+            self.symptomID = bytes.decode(
+                self.stream.get_mem(self.symptomIDSize))
+        else:
+            self.symptomID = ''
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Reporting Machine Type"] = self.machineType
+        out["Reporting Serial Number"] = self.serialNumber.strip("\u0000")
+        out["FW Released Ver"] = self.serverFWVersion.strip("\u0000")
+        out["FW SubSys Version"] = self.subsystemFWVersion.strip("\u0000")
+        out["Common Ref Time"] = self.refTime
+        out["Symptom Id Len"] = str(self.symptomIDSize)
+        out["Symptom Id"] = self.symptomID.strip("\u0000")
+
+        return out

--- a/modules/pel/peltool/failing_mtms.py
+++ b/modules/pel/peltool/failing_mtms.py
@@ -1,0 +1,38 @@
+from pel.datastream import DataStream
+from pel.peltool.comp_id import getDisplayCompID
+from collections import OrderedDict
+
+
+class FailingMTMS:
+    """
+    This represents the Failing Enclosure MTMS section in a PEL.
+    It is a required section.  In the BMC case, the enclosure is
+    the system enclosure.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.reserved0 = 0
+        self.reserved1 = 0
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.machineType = ""
+        self.serialNumber = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.machineType = bytes.decode(self.stream.get_mem(8))
+        self.serialNumber = bytes.decode(self.stream.get_mem(12))
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Machine Type Model"] = self.machineType.strip("\u0000")
+        out["Serial Number"] = self.serialNumber.strip("\u0000")
+
+        return out

--- a/modules/pel/peltool/imp_partition.py
+++ b/modules/pel/peltool/imp_partition.py
@@ -1,0 +1,62 @@
+from pel.datastream import DataStream
+from pel.peltool.comp_id import getDisplayCompID
+from collections import OrderedDict
+
+
+class ImpactedPartition:
+    """
+    This represents the Impacted Partition section in a PEL.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.primaryPartID = 0
+        self.lpNameLength = 0
+        self.targetLPcount = 0
+        self.logicalPartLogID = 0
+        self.lpName = ""
+        self.targetLPs = []
+
+    def toJSON(self) -> OrderedDict:
+        self.primaryPartID = self.stream.get_int(2)
+        self.lpNameLength = self.stream.get_int(1)
+        self.targetLPcount = self.stream.get_int(1)
+        self.logicalPartLogID = self.stream.get_int(4)
+
+        if self.lpNameLength:
+            self.lpName = bytes.decode(
+                self.stream.get_mem(self.lpNameLength)).rstrip('\x00')
+
+        if self.targetLPcount:
+            for _ in range(self.targetLPcount):
+                self.targetLPs.append(self.stream.get_int(2))
+
+        # PEL sections are 4 byte aligned, so may need
+        # to advance the stream past the padding to get ready
+        # for next section.
+        if self.targetLPcount % 2:
+            _ = self.stream.get_int(2)
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        out["Primary Partition ID"] = "0x{:04X}".format(self.primaryPartID)
+        out["Length of LP Name"] = "0x{:02X}".format(self.lpNameLength)
+        out["Target LP Count"] = "0x{:02X}".format(self.targetLPcount)
+        out["Logical Partition Log ID"] = "0x{:08X}".format(
+            self.logicalPartLogID)
+        out["Primary Partition Name"] = self.lpName
+
+        for i in range(self.targetLPcount):
+            out["Target LP"] = "0x{:04X}".format(self.targetLPs[i])
+
+        return out

--- a/modules/pel/peltool/parse_user_data.py
+++ b/modules/pel/peltool/parse_user_data.py
@@ -1,0 +1,96 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import creatorIDs
+from pel.hexdump import hexdump
+from enum import Enum, unique
+import json
+import sys
+
+
+@unique
+class UserDataFormat(Enum):
+    json = 0x1
+    cbor = 0x2
+    text = 0x3
+    custom = 0x4
+
+
+def get_value(data: memoryview, start: int, end: int) -> int:
+    return int.from_bytes(data[start: start + end], byteorder="big")
+
+
+class ParseUserData:
+    """
+    The toJSON() function handles parsing the data from either UserData or
+    ExtUserData sections.
+    """
+
+    def __init__(self, creatorID: str, compID: str, subType: int, version: int,
+                 data: bytes):
+        self.creatorID = creatorID
+        self.compID = compID
+        self.subType = subType
+        self.version = version
+        self.data = data
+
+    def parse(self) -> str:
+        if self.creatorID in creatorIDs and creatorIDs[self.creatorID] == "BMC" \
+                and self.compID == 0x2000:
+            value = self.getBuiltinFormatJSON()
+        else:
+            value = self.parseCustom()
+
+        return value
+
+    def parseCustom(self) -> str:
+        import importlib
+        name = (self.creatorID.lower() + "%04X" % self.compID).lower()
+        try:
+            cls = importlib.import_module("udparsers." + name + "." + name)
+            mv = memoryview(self.data)
+            return cls.parseUDToJson(self.subType, self.version, mv)
+        except ImportError:
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+        except Exception as e:
+            print('Failed parsing user data for creator {} compID {} '
+                  'subType {} version {}: {}'.format(
+                      self.creatorID, "0x%04X" % self.compID,
+                      "0x%X" % self.subType, self.version, str(e)), file=sys.stderr)
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+
+    def getBuiltinFormatJSON(self) -> str:
+        if self.subType == UserDataFormat.json.value:
+            string = bytes.decode(self.data).strip().rstrip('\x00')
+            return string
+        elif self.subType == UserDataFormat.cbor.value:
+            # TODO, support CBOR (binary JSON)
+            # pad = get_value(self.stream.data, self.dataLength - 4, 4)
+            # if self.dataLength > pad + 4:
+            #     self.dataLength = self.dataLength - pad - 4
+            # out.update(json.loads(bytes.decode(
+            #     self.stream.get_mem(self.dataLength)).strip()))
+
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))
+
+        elif self.subType == UserDataFormat.text.value:
+            lines = []
+            line = ''
+            for ch in bytes.decode(self.data).strip().rstrip('\x00'):
+                if ch != '\n':
+                    if ord(ch) < ord(' ') or ord(ch) > ord('~'):
+                        ch = '.'
+                    line += ch
+                else:
+                    lines.append(line)
+                    line = ''
+
+            if line != '':
+                lines.append(line)
+
+            return json.dumps(lines)
+        else:
+            mv = memoryview(self.data)
+            return json.dumps(hexdump(mv))

--- a/modules/pel/peltool/pel_types.py
+++ b/modules/pel/peltool/pel_types.py
@@ -1,0 +1,37 @@
+from enum import Enum, unique
+
+
+@unique
+class TransmissionState(Enum):
+    newPEL = 0
+    badPEL = 1
+    sent = 2
+    acked = 3
+
+
+@unique
+class SectionID(Enum):
+    privateHeader = 0x5048         # 'PH'
+    userHeader = 0x5548            # 'UH'
+    primarySRC = 0x5053            # 'PS'
+    secondarySRC = 0x5353          # 'SS'
+    extendedUserHeader = 0x4548    # 'EH'
+    failingMTMS = 0x4D54           # 'MT'
+    dumpLocation = 0x4448          # 'DH'
+    firmwareError = 0x5357         # 'SW'
+    impactedPart = 0x4C50          # 'LP'
+    logicalResource = 0x4C52       # 'LR'
+    hmcID = 0x484D                 # 'HM'
+    epow = 0x4550                  # 'EP'
+    ioEvent = 0x4945               # 'IE'
+    mfgInfo = 0x4D49               # 'MI'
+    callhome = 0x4348              # 'CH'
+    userData = 0x5544              # 'UD'
+    envInfo = 0x4549               # 'EI'
+    extUserData = 0x4544           # 'ED'
+
+
+@unique
+class SRCType(Enum):
+    bmcError = "BD"
+    powerError = "11"

--- a/modules/pel/peltool/pel_values.py
+++ b/modules/pel/peltool/pel_values.py
@@ -1,0 +1,233 @@
+from pel.peltool.pel_types import TransmissionState
+
+"""
+Creator IDs
+"""
+creatorIDs = {"B": "Hostboot", "C": "HMC", "H": "PHYP", "K": "Sapphire",
+              "L": "Partition FW", "M": "I/O Drawer", "O": "BMC",
+              "P": "PowerNV", "S": "SLIC",  "T": "OCC"}
+
+"""
+Section Names
+"""
+sectionNames = {
+    "PH": "Private Header",
+    "UH": "User Header",
+    "PS": "Primary SRC",
+    "SS": "Secondary SRC",
+    "EH": "Extended User Header",
+    "MT": "Failing MTMS",
+    "DH": "Dump Location",
+    "SW": "Firmware Error",
+    "LP": "Impacted Partition",
+    "LR": "Logical Resource",
+    "HM": "HMC ID",
+    "EP": "EPOW",
+    "IE": "IO Event",
+    "MI": "MFG Info",
+    "CH": "Call Home",
+    "UD": "User Data",
+    "EI": "Env Info",
+    "ED": "Extended User Data"}
+
+"""
+The possible values for the subsystem field  in the User Header.
+"""
+subsystemValues = {
+    0x10: "Processor",
+    0x11: "Processor FRU",
+    0x12: "Processor Chip Cache",
+    0x13: "Processor Unit (CPU)",
+    0x14: "Processor Bus Controller",
+
+    0x20: "Memory ",
+    0x21: "Memory Controller",
+    0x22: "Memory Bus Interface",
+    0x23: "Memory DIMM",
+    0x24: "Memory Card/FRU",
+    0x25: "External Cache",
+
+    0x30: "I/O",
+    0x31: "I/O Hub",
+    0x32: "I/O Bridge",
+    0x33: "I/O bus interface",
+    0x34: "I/O Processor",
+    0x35: "SMA Hub",
+    0x38: "PCI Bridge Chip",
+
+    0x40: "I/O Adapter",
+    0x41: "I/O Adapter Communication",
+    0x46: "I/O Device",
+    0x47: "I/O Device Disk",
+    0x4C: "I/O External Peripheral",
+    0x4D: "I/O External Peripheral Local Work Station",
+    0x4E: "I/O Storage Mezza Expansion",
+
+    0x50: "CEC Hardware",
+    0x51: "CEC Hardware - Service Processor A",
+    0x52: "CEC Hardware - Service Processor B",
+    0x53: "CEC Hardware - Node Controller",
+    0x55: "CEC Hardware - VPD Interface",
+    0x56: "CEC Hardware - I2C Devices",
+    0x57: "CEC Hardware - CEC Chip Interface",
+    0x58: "CEC Hardware - Clock",
+    0x59: "CEC Hardware - Operator Panel",
+    0x5A: "CEC Hardware - Time-Of-Day Hardware",
+    0x5B: "CEC Hardware - Memory Device",
+    0x5C: "CEC Hardware - Hypervisor<->Service Processor Interface",
+    0x5D: "CEC Hardware - Service Network",
+    0x5E: "CEC Hardware - Hostboot-Service Processor Interface",
+
+    0x60: "Power/Cooling",
+    0x61: "Power Supply",
+    0x62: "Power Control Hardware",
+    0x63: "Fan (AMD)",
+    0x64: "Digital Power Supply",
+
+    0x70: "Miscellaneous",
+    0x71: "HMC & Hardware",
+    0x72: "Test Tool",
+    0x73: "Removable Media",
+    0x74: "Multiple Subsystems",
+    0x75: "Not Applicable",
+    0x76: "Miscellaneous",
+
+    0x7A: "Hypervisor lost communication with service processor",
+    0x7B: "Service processor lost communication with Hypervisor",
+    0x7C: "Service processor lost communication with HMC",
+    0x7D: "HMC lost communication with logical partition",
+    0x7E: "HMC lost communication with BPA",
+    0x7F: "HMC lost communication with another HMC",
+
+    0x80: "Platform Firmware",
+    0x81: "Service Processor Firmware",
+    0x82: "System Hypervisor Firmware",
+    0x83: "Partition Firmware",
+    0x84: "SLIC Firmware",
+    0x85: "System Power Control Network Firmware",
+    0x86: "Bulk Power Firmware Side A",
+    0x87: "HMC Code",
+    0x88: "Bulk Power Firmware Side B",
+    0x89: "Virtual Service Processor Firmware",
+    0x8A: "HostBoot",
+    0x8B: "OCC",
+    0x8D: "BMC Firmware",
+
+    0x90: "Software",
+    0x91: "Operating System software",
+    0x92: "XPF software",
+    0x93: "Application software",
+
+    0xA0: "External Environment",
+    0xA1: "Input Power Source (ac)",
+    0xA2: "Room Ambient Temperature",
+    0xA3: "User Error",
+    0xA4: "Corrosion"}
+
+
+"""
+The possible values for the Event Scope field in the User Header.
+"""
+eventScopeValues = {
+    0x01: "Single Partition",
+    0x02: "Multiple Partitions",
+    0x03: "Entire Platform",
+    0x04: "Multiple Platforms"}
+
+
+"""
+The possible values for the Event Type field in the User Header.
+"""
+eventTypeValues = {
+    0x00: "Not Applicable",
+    0x01: "Miscellaneous, Informational Only",
+    0x02: "Tracing Event",
+    0x08: "Dump Notification",
+    0x30: "Customer environmental problem back to normal"}
+
+
+"""
+The possible values for the severity field in the User Header.
+"""
+severityValues = {
+    0x00: "Informational Event",
+
+    0x10: "Recovered Error",
+    0x20: "Predictive Error",
+    0x21: "Predictive Error, Degraded Performance",
+    0x22: "Predictive Error, Correctable",
+    0x23: "Predictive Error, Correctable, Degraded",
+    0x24: "Predictive Error, Redundancy Lost",
+
+    0x40: "Unrecoverable Error",
+    0x41: "Unrecoverable Error, Degraded Performance",
+    0x44: "Unrecoverable Error, Loss of Redundancy",
+    0x45: "Unrecoverable, Loss of Redundancy + Performance",
+    0x48: "Unrecoverable Error, Loss of Function",
+
+    0x50: "Critical Error, Scope of Failure unknown",
+    0x51: "Critical Error, System Termination",
+    0x52: "Critical Error, System Failure likely or imminent",
+    0x53: "Critical Error, Partition(s) Termination",
+    0x54: "Critical Error, Partition(s) Failure likely or imminent",
+
+    0x60: "Error detected during diagnostic test",
+    0x61: "Diagostic error, resource w/incorrect results",
+
+    0x71: "Symptom Recovered",
+    0x72: "Symptom Predictive",
+    0x74: "Symptom Unrecoverable",
+    0x75: "Symptom Critical",
+    0x76: "Symptom Diag Err"}
+
+
+"""
+The possible values for the Action Flags field in the User Header.
+"""
+actionFlagsValues = {
+    0x8000: "Service Action Required",
+    0x4000: "Event not customer viewable",
+    0x2000: "Report Externally",
+    0x1000: "Do Not Report To Hypervisor",
+    0x0800: "HMC Call Home",
+    0x0400: "Isolation Incomplete, further analysis required",
+    0x0100: "Service Processor Call Home Required"}
+
+"""
+Map for transmission states
+"""
+transmissionStates = {
+    TransmissionState.newPEL.value: "Not Sent",
+    TransmissionState.badPEL.value: "Rejected",
+    TransmissionState.sent.value: "Sent",
+    TransmissionState.acked.value: "Acked"}
+
+"""
+Map for Callout Failing Component Types
+"""
+failingComponentType = {
+    0x10: "Normal Hardware FRU",
+    0x20: "Code FRU",
+    0x30: "Configuration error, configuration procedure required",
+    0x40: "Maintenance Procedure Required",
+    0x90: "External FRU",
+    0xA0: "External Code FRU",
+    0xB0: "Tool FRU",
+    0xC0: "Symbolic FRU",
+    0xE0: "Symbolic FRU with trusted location code"}
+
+"""
+The possible values for the Callout Priority field in the SRC.
+"""
+calloutPriorityValues = {
+    0x48: "Mandatory, replace all with this type as a unit",
+    0x4D: "Medium Priority",
+    0x41: "Medium Priority A, replace these as a group",
+    0x42: "Medium Priority B, replace these as a group",
+    0x43: "Medium Priority C, replace these as a group",
+    0x4C: "Lowest priority replacement"}
+
+"""
+Map for Procedure Descriptions
+"""
+procedureDesc = {"TODO": "TODO"}

--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import os
+import json
+import argparse
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.private_header import PrivateHeader
+from pel.peltool.user_header import UserHeader
+from pel.peltool.src import SRC
+from pel.peltool.pel_types import SectionID
+from pel.peltool.extend_user_header import ExtendedUserHeader
+from pel.peltool.failing_mtms import FailingMTMS
+from pel.peltool.user_data import UserData
+from pel.peltool.ext_user_data import ExtUserData
+from pel.peltool.default import Default
+from pel.peltool.imp_partition import ImpactedPartition
+from pel.peltool.pel_values import sectionNames
+
+
+def getSectionName(sectionID: int) -> str:
+    id = chr((sectionID >> 8) & 0xFF) + chr(sectionID & 0xFF)
+    return sectionNames.get(id, 'Unknown')
+
+
+def parserHeader(stream: DataStream):
+    sectionID = stream.get_int(2)
+    sectionLen = stream.get_int(2)
+    versionID = stream.get_int(1)
+    subType = stream.get_int(1)
+    componentID = stream.get_int(2)
+    return sectionID, sectionLen, versionID, subType, componentID
+
+
+def generatePH(stream: DataStream, out: OrderedDict) -> (bool, PrivateHeader):
+    sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+        stream)
+    if sectionID != SectionID.privateHeader.value:
+        print("Failed to parser Private Header, section ID = %x" % (sectionID))
+        return False, None
+
+    ph = PrivateHeader(stream, sectionID, sectionLen,
+                       versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ph.toJSON()
+    return True, ph
+
+
+def generateUH(stream: DataStream, creatorID: str, out: OrderedDict) -> (bool, UserHeader):
+    sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+        stream)
+    if sectionID != SectionID.userHeader.value:
+        print("Failed to parser User Header, section ID = %d" % (sectionID))
+        return False, None
+
+    uh = UserHeader(stream, sectionID, sectionLen,
+                    versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = uh.toJSON()
+    return True, uh
+
+
+def generateSRC(stream: DataStream, out: OrderedDict,
+                sectionID: int, sectionLen: int, versionID: int, subType: int,
+                componentID: int, creatorID: str) -> (bool, SRC):
+    src = SRC(stream, sectionID, sectionLen,
+              versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = src.toJSON()
+    return True, src
+
+
+def generateEH(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, ExtendedUserHeader):
+    eh = ExtendedUserHeader(stream, sectionID, sectionLen,
+                            versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = eh.toJSON()
+    return True, eh
+
+
+def generateMT(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, FailingMTMS):
+    mt = FailingMTMS(stream, sectionID, sectionLen,
+                     versionID, subType, componentID, creatorID)
+    out[getSectionName(sectionID)] = mt.toJSON()
+    return True, mt
+
+
+def generateED(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int) -> (bool, ExtUserData):
+    ed = ExtUserData(stream, sectionID, sectionLen,
+                     versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ed.toJSON()
+    return True, ed
+
+
+def generateUD(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, UserData):
+    ud = UserData(stream, sectionID, sectionLen, versionID,
+                  subType, componentID, creatorID)
+
+    out[getSectionName(sectionID)] = ud.toJSON()
+    return True, ud
+
+
+def generateIP(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str) -> (bool, ExtUserData):
+    ip = ImpactedPartition(stream, sectionID, sectionLen,
+                           versionID, subType, componentID,
+                           creatorID)
+    out[getSectionName(sectionID)] = ip.toJSON()
+    return True, ip
+
+
+def generateDefault(stream: DataStream, out: OrderedDict, sectionID: int,
+                    sectionLen: int, versionID: int, subType: int,
+                    componentID: int) -> (bool, ExtUserData):
+    ed = Default(stream, sectionID, sectionLen,
+                 versionID, subType, componentID)
+    out[getSectionName(sectionID)] = ed.toJSON()
+    return True, ed
+
+
+def sectionFun(stream: DataStream, out: OrderedDict, sectionID: int,
+               sectionLen: int, versionID: int, subType: int,
+               componentID: int, creatorID: str):
+    if sectionID == SectionID.primarySRC.value or \
+            sectionID == SectionID.secondarySRC.value:
+        generateSRC(stream, out, sectionID, sectionLen,
+                    versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.extendedUserHeader.value:
+        generateEH(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.failingMTMS.value:
+        generateMT(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.extUserData.value:
+        generateED(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID)
+    elif sectionID == SectionID.userData.value:
+        generateUD(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    elif sectionID == SectionID.impactedPart.value:
+        generateIP(stream, out, sectionID, sectionLen,
+                   versionID, subType, componentID, creatorID)
+    else:
+        generateDefault(stream, out, sectionID, sectionLen,
+                        versionID, subType, componentID)
+
+
+def buildOutput(sections: list, out: OrderedDict):
+    counts = {}
+
+    # Find the section names that appear more than once.
+    # counts[section name] = [# occurrences, counter]
+    for section_num in range(len(sections)):
+        name = list(sections[section_num].keys())[0]
+        if name not in counts:
+            counts[name] = [1, 0]
+        else:
+            counts[name] = [counts[name][0]+1, 0]
+
+    # For sections that appear more than once, add a
+    # ' <count>' to the name, eg 'User Data 1'.
+    for section_num in range(len(sections)):
+        name = list(sections[section_num].keys())[0]
+
+        if counts[name][0] == 1:
+            out[name] = sections[section_num][name]
+        else:
+            modifier = counts[name][1]
+            out[name + ' ' + str(modifier)] = sections[section_num][name]
+            counts[name][1] = modifier + 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PELTools")
+
+    parser.add_argument('-f', '--file', dest='file',
+                        help='input pel file to parse')
+    args = parser.parse_args()
+
+    with open(args.file, 'rb') as fd:
+        data = fd.read()
+        stream = DataStream(data, byte_order='big', is_signed=False)
+        out = OrderedDict()
+        ret, ph = generatePH(stream, out)
+        if ret == False:
+            return
+
+        ret, _ = generateUH(stream, ph.creatorID, out)
+        if ret == False:
+            return
+
+        section_jsons = []
+        for _ in range(2, ph.sectionCount):
+            sectionID, sectionLen, versionID, subType, componentID = parserHeader(
+                stream)
+            section_json = {}
+            sectionFun(stream, section_json, sectionID, sectionLen,
+                       versionID, subType, componentID, ph.creatorID)
+            section_jsons.append(section_json)
+
+        buildOutput(section_jsons, out)
+
+        print(json.dumps(out, indent=4))
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/pel/peltool/private_header.py
+++ b/modules/pel/peltool/private_header.py
@@ -1,0 +1,75 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import creatorIDs
+from pel.peltool.comp_id import getDisplayCompID
+
+
+def getTimestamp(stream: DataStream) -> str:
+    year = stream.get_mem(2).hex()
+    month = stream.get_mem(1).hex()
+    day = stream.get_mem(1).hex()
+    hour = stream.get_mem(1).hex()
+    min = stream.get_mem(1).hex()
+    sec = stream.get_mem(1).hex()
+    hundredths = stream.get_mem(1).hex()
+    #  "03/08/2022 18:40:27"
+    createTime = month + "/" + day + "/" + year + " " + hour + ":" + min + ":" + sec
+    return createTime
+
+
+class PrivateHeader:
+    """
+    This represents the Private Header section in a PEL.  It is required,
+    and it is always the first section.
+
+    The Section base class handles the section header structure that every
+    PEL section has at offset zero.
+
+    The fields in this class directly correspond to the order and sizes of
+    the fields in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.reserved0 = 0
+        self.reserved1 = 0
+        self.subType = subType
+        self.componentID = componentID
+        self.sectionCount = 0
+        self.creatorID = ""
+        self.obmcLogID = 0
+        self.creatorVersion = 0
+        self.pLID = ""
+        self.lEID = ""
+        self.createTime = ""
+        self.committeTime = ""
+
+    def toJSON(self) -> OrderedDict:
+        self.createTime = getTimestamp(self.stream)
+        self.committeTime = getTimestamp(self.stream)
+        self.creatorID = bytes.decode(self.stream.get_mem(1))
+        self.reserved0 = self.stream.get_int(1)
+        self.reserved1 = self.stream.get_int(1)
+        self.sectionCount = self.stream.get_int(1)
+        self.obmcLogID = self.stream.get_int(4)
+        self.creatorVersion = "0x{:02X}".format(self.stream.get_int(8))
+        self.pLID = "0x{:02X}".format(self.stream.get_int(4))
+        self.lEID = "0x{:02X}".format(self.stream.get_int(4))
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["Created at"] = self.createTime
+        out["Committed at"] = self.committeTime
+        out["Creator Subsystem"] = creatorIDs.get(self.creatorID, 'Unknown')
+        out["CSSVER"] = self.creatorVersion
+        out["Platform Log Id"] = self.pLID
+        out["Entry Id"] = self.lEID
+        out["BMC Event Log Id"] = str(self.obmcLogID)
+
+        return out

--- a/modules/pel/peltool/registry.py
+++ b/modules/pel/peltool/registry.py
@@ -1,0 +1,53 @@
+import json
+import os
+
+
+class Registry:
+    def __init__(self):
+        try:
+            import pel_registry
+            path = pel_registry.get_registry_path()
+        except ModuleNotFoundError:
+            # On the BMC, pel_registry isn't available, so just
+            # use the known location.
+            path = \
+                '/usr/share/phosphor-logging/pels/message_registry.json'
+            if not os.path.exists(path):
+                path = ''
+
+        if path:
+            self.pels = self.loadJson(path)
+        else:
+            self.pels = []
+
+    def loadJson(self, path: str):
+        with open(path, "r") as f:
+            load_dict = json.load(f)
+            return load_dict["PELs"]
+
+    def getErrorMessage(self, code: str, srcType: str) -> dict:
+        output = {}
+
+        for pel in self.pels:
+            if "ReasonCode" not in pel["SRC"]:
+                continue
+
+            entryType = pel["SRC"].get("Type", "BD")
+            if srcType != entryType:
+                continue
+
+            if code not in pel["SRC"]["ReasonCode"]:
+                continue
+
+            output['Message'] = pel['Documentation']['Message']
+
+            if ('MessageArgSources' in pel['Documentation']):
+                output['MessageArgSources'] = \
+                    pel['Documentation']['MessageArgSources']
+
+            if 'Words6To9' in pel['SRC'] and pel['SRC']['Words6To9']:
+                output['Words6To9'] = pel['SRC']['Words6To9']
+
+            return output
+
+        return output

--- a/modules/pel/peltool/src.py
+++ b/modules/pel/peltool/src.py
@@ -1,0 +1,347 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from enum import Enum, unique
+from pel.peltool.pel_types import SRCType
+from pel.peltool.registry import Registry
+from pel.peltool.pel_values import failingComponentType, \
+    calloutPriorityValues, procedureDesc
+from pel.peltool.comp_id import getDisplayCompID
+import json
+import sys
+
+
+@unique
+class HeaderFlags(Enum):
+    additionalSections = 0x01
+    powerFaultEvent = 0x02
+    hypDumpInit = 0x04
+    postOPPanel = 0x08
+    i5OSServiceEventBit = 0x10
+    virtualProgressSRC = 0x80
+
+
+@unique
+class ErrorStatusFlags(Enum):
+    terminateFwErr = 0x20000000
+    deconfigured = 0x02000000
+    guarded = 0x01000000
+
+
+@unique
+class Flags(Enum):
+    pnSupplied = 0x08
+    ccinSupplied = 0x04
+    maintProcSupplied = 0x02
+    snSupplied = 0x01
+
+
+def get_value(data: memoryview, start: int, end: int) -> int:
+    return int.from_bytes(data[start: start + end], byteorder="big")
+
+
+class FRUIdentity:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.size = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.pnOrProcedureID = ""
+        self.ccin = ""
+        self.sn = ""
+        self.flattenedSize = 4
+
+        if self.flags & Flags.pnSupplied.value or self.flags & Flags.maintProcSupplied.value:
+            self.pnOrProcedureID = bytes.decode(
+                stream.get_mem(8)).strip("\u0000")
+            self.flattenedSize += 8
+
+        if self.flags & Flags.ccinSupplied.value:
+            self.ccin = bytes.decode(stream.get_mem(4)).strip("\u0000")
+            self.flattenedSize += 4
+
+        if self.flags & Flags.snSupplied.value:
+            self.sn = bytes.decode(stream.get_mem(12)).strip("\u0000")
+            self.flattenedSize += 12
+
+
+class PCEIdentity:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.flattenedSize = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.machineType = bytes.decode(stream.get_mem(8)).strip("\u0000")
+        self.serialNumber = bytes.decode(
+            stream.get_mem(12)).strip("\u0000")
+        if self.flattenedSize < (4 + 8 + 12):
+            print("PCE identity structure size field too small")
+            return
+        self.pceNameSize = self.flattenedSize - (4 + 8 + 12)
+        self.pceName = bytes.decode(
+            stream.get_mem(self.pceNameSize)).strip("\u0000")
+
+
+class MRUCallout:
+    def __init__(self, priority: int, id: int) -> None:
+        self.priority = priority
+        self.id = id
+
+
+class MRU:
+    def __init__(self, stream: DataStream):
+        self.type = stream.get_int(2)
+        self.flattenedSize = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.reserved4B = stream.get_int(4)
+        self.mrus = []
+        for _ in range(self.flags & 0xf):
+            mru = MRUCallout(stream.get_int(4), stream.get_int(4))
+            self.mrus.append(mru)
+
+
+class Callout:
+    def __init__(self, stream: DataStream):
+        self.size = stream.get_int(1)
+        self.flags = stream.get_int(1)
+        self.priority = stream.get_int(1)
+        self.locationCode = ""
+        self.locationCodeSize = stream.get_int(1)
+        if self.locationCodeSize > 0:
+            self.locationCode = bytes.decode(
+                stream.get_mem(self.locationCodeSize)).strip("\u0000")
+        self.fruIdentity = None
+        self.pceIdentity = None
+        self.mru = None
+
+        currentSize = 4 + self.locationCodeSize
+        while self.size > currentSize:
+            type = get_value(stream.data, stream.index, 2)
+            if type == 0x4944:
+                self.fruIdentity = FRUIdentity(stream)
+            elif type == 0x5045:
+                self.pceIdentity = PCEIdentity(stream)
+            elif type == 0x4D52:
+                self.mru = MRU(stream)
+            else:
+                break
+
+    def flattenedSize(self):
+        size = 4 + self.locationCodeSize
+        size += self.fruIdentity.flattenedSize if self.fruIdentity else 0
+        size += self.pceIdentity.flattenedSize if self.pceIdentity else 0
+        size += self.mru.flattenedSize if self.mru else 0
+        return size
+
+
+class SRC:
+    """
+    SRC stands for System Reference Code.
+
+    This class represents the SRC sections in the PEL, of which there are 2:
+    primary SRC and secondary SRC.  These are the same structurally, the
+    difference is that the primary SRC must be the 3rd section in the PEL if
+    present and there is only one of them, and the secondary SRC sections are
+    optional and there can be more than one (by definition, for there to be a
+    secondary SRC, a primary SRC must also exist).
+
+    This section consists of:
+    - An 8B header (Has the version, flags, hexdata word count, and size fields)
+    - 8 4B words of hex data
+    - An ASCII character string
+    - An optional subsection for Callouts
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.version = 0
+        self.flags = 0
+        self.reserved1B = 0
+        self.wordCount = 0
+        self.reserved2B = 0
+        self.size = 0
+        self.hexData = []
+        self.srcType = 0
+        self.asciiString = ""
+
+    def buildMessage(self, details: dict) -> str:
+        if 'Message' not in details:
+            return ''
+
+        message = details['Message']
+        if 'MessageArgSources' in details:
+            hexword_args = []
+
+            # Strip off the word number from SRCWordN and subtract 2 to get
+            # the hexData word to use
+            for arg in details['MessageArgSources']:
+                hexword_args.append(hex(self.hexData[int(arg[-1]) - 2]))
+
+            # message may have %1, etc. replace with {} and then fill
+            # those in with the hexData words
+            import re
+            message = re.sub(r'%[1-9]', "{}", message)
+            message = message.format(*hexword_args)
+
+        return message
+
+    def buildHexwordDescs(self, details: dict) -> OrderedDict:
+        descriptions = OrderedDict()
+        if 'Words6To9' not in details or not details['Words6To9']:
+            return
+
+        for num, word_contents in details['Words6To9'].items():
+            # Nobody wants to see these if no description
+            if 'Description' not in word_contents:
+                continue
+
+            index = int(num) - 2
+            descriptions[word_contents['AdditionalDataPropSource']] = \
+                [self.hexData[index], word_contents['Description']]
+
+        return descriptions
+
+    def getErrorDetails(self, out: OrderedDict, code: str, srcType: str):
+        code = "0x" + code
+        registry = Registry()
+        details = registry.getErrorMessage(code, srcType)
+
+        od = OrderedDict()
+        od["Message"] = self.buildMessage(details)
+        if od["Message"]:
+            descs = self.buildHexwordDescs(details)
+            if descs:
+                od.update(descs)
+
+            out["Error Details"] = od
+
+    def getCallouts(self, out: OrderedDict):
+        od = OrderedDict()
+        _ = self.stream.get_int(1)  # subsectionID
+        _ = self.stream.get_int(1)  # subsectionFlags
+        subsectionWordLength = self.stream.get_int(2)
+        currentLength = 4
+        callouts = []
+        while subsectionWordLength * 4 > currentLength:
+            callout = Callout(self.stream)
+            callouts.append(callout)
+            currentLength += callout.flattenedSize()
+        od["Callout Count"] = len(callouts)
+        calloutJsons = []
+        for callout in callouts:
+            json = OrderedDict()
+            if callout.fruIdentity:
+                json["FRU Type"] = \
+                    failingComponentType.get(callout.fruIdentity.flags & 0xf0,
+                                             'Invalid')
+                json["Priority"] = calloutPriorityValues.get(
+                    callout.priority, 'Invalid')
+                if len(callout.locationCode) > 0:
+                    json["Location Code"] = callout.locationCode
+                if callout.fruIdentity.flags & Flags.pnSupplied.value:
+                    json["Part Number"] = callout.fruIdentity.pnOrProcedureID
+                if callout.fruIdentity.flags & Flags.maintProcSupplied.value:
+                    json["Procedure"] = callout.fruIdentity.pnOrProcedureID
+                    if callout.fruIdentity.pnOrProcedureID in procedureDesc:
+                        json["Description"] = \
+                            procedureDesc[callout.fruIdentity.pnOrProcedureID]
+                if callout.fruIdentity.flags & Flags.ccinSupplied.value:
+                    json["CCIN"] = callout.fruIdentity.ccin
+                if callout.fruIdentity.flags & Flags.snSupplied.value:
+                    json["Serial Number"] = callout.fruIdentity.sn
+
+            if callout.pceIdentity:
+                if len(callout.pceIdentity.machineType) > 0:
+                    json["PCE MTMS"] = callout.pceIdentity.machineType + \
+                        "_" + callout.pceIdentity.serialNumber
+                if len(callout.pceIdentity.pceName):
+                    json["PCE Name"] = callout.pceIdentity.pceName
+
+            if callout.mru:
+                mru = OrderedDict()
+                mruId = ""
+                for mru in callout.mru.mrus:
+                    mruId += "%08X" % mru.id + ","
+                json["MRU Id"] = mruId[:-1]
+
+            calloutJsons.append(json)
+        od["Callouts"] = calloutJsons
+        out["Callout Section"] = od
+
+    def parse(self, hexwords: list) -> str:
+        if len(hexwords) < 8:
+            print("The length of the hexwords < 8, exit")
+            exit(1)
+
+        name = self.creatorID.lower() + "src"
+        try:
+            import importlib
+            cls = importlib.import_module("srcparsers." + name + "." + name)
+        except:
+            return ""
+
+        try:
+            return cls.parseSRCToJson(self.asciiString, hexwords[0], hexwords[1], hexwords[2],
+                                      hexwords[3], hexwords[4], hexwords[5], hexwords[6], hexwords[7])
+        except Exception as e:
+            print('Error getting SRC details for {}: {}'.format(
+                self.asciiString.rstrip(), str(e)), file=sys.stderr)
+            return ''
+
+    def toJSON(self) -> OrderedDict:
+        self.version = "0x" + self.stream.get_mem(1).hex()
+        self.flags = self.stream.get_int(1)
+        self.reserved1B = self.stream.get_int(1)
+        self.wordCount = self.stream.get_int(1)
+        self.reserved2B = self.stream.get_int(2)
+        self.size = self.stream.get_int(2)
+        for i in range(8):
+            self.hexData.append(self.stream.get_int(4))
+        self.asciiString = bytes.decode(self.stream.get_mem(32))
+        self.srcType = self.asciiString[0:2]
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+        out["SRC Version"] = self.version
+        out["SRC Format"] = "0x{:02X}".format(self.hexData[0] & 0xFF)
+        out["Virtual Progress SRC"] = "True" if self.flags & HeaderFlags.virtualProgressSRC.value else "False"
+        out["I5/OS Service Event Bit"] = "True" if self.flags & HeaderFlags.i5OSServiceEventBit.value else "False"
+        out["Hypervisor Dump Initiated"] = "True" if self.flags & HeaderFlags.hypDumpInit.value else "False"
+        if self.srcType == SRCType.bmcError.value or self.srcType == SRCType.powerError.value:
+            out["Backplane CCIN"] = str("%04X" % (self.hexData[1] >> 16))
+            out["Terminate FW Error"] = "True" if self.hexData[3] & ErrorStatusFlags.terminateFwErr.value else "False"
+            out["Deconfigured"] = "True" if self.hexData[3] & ErrorStatusFlags.deconfigured.value else "False"
+            out["Guarded"] = "True" if self.hexData[3] & ErrorStatusFlags.guarded.value else "False"
+            self.getErrorDetails(
+                out, self.asciiString[4:8], self.asciiString[0:2])
+
+        out["Valid Word Count"] = "0x" + "%02X" % self.wordCount
+        out["Reference Code"] = self.asciiString.strip()
+
+        hexwords = []
+        for i in range(2, self.wordCount + 1):
+            num = i
+            if num >= 2 and num <= 9:
+                num -= 2
+            tmpWord = "%08X" % self.hexData[num]
+            out["Hex Word " + str(i)] = tmpWord
+            hexwords.append(tmpWord)
+
+        # add zeroes to get 8 hexwords for parse()
+        while len(hexwords) < 8:
+            hexwords.append('00000000')
+
+        if self.flags & HeaderFlags.additionalSections.value:
+            self.getCallouts(out)
+
+        value = self.parse(hexwords)
+        if value != '' and value != 'null':
+            out["SRC Details"] = json.loads(value)
+
+        return out

--- a/modules/pel/peltool/user_data.py
+++ b/modules/pel/peltool/user_data.py
@@ -1,0 +1,46 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+import json
+from pel.peltool.parse_user_data import ParseUserData
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class UserData:
+    """
+    This represents the User Data section in a PEL.  It is free form data
+    that the creator knows the contents of.  The component ID, version,
+    and sub-type fields in the section header are used to identify the
+    format.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.dataLength = sectionLen - 8
+        self.data = self.stream.get_mem(self.dataLength)
+
+    def toJSON(self) -> OrderedDict:
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Created by"] = getDisplayCompID(self.componentID, self.creatorID)
+
+        parser = ParseUserData(self.creatorID, self.componentID, self.subType,
+                               self.versionID, self.data)
+
+        value = parser.parse()
+
+        j = json.loads(value)
+        if not isinstance(j, dict):
+            out['Data'] = j
+        else:
+            out.update(j)
+
+        return out

--- a/modules/pel/peltool/user_header.py
+++ b/modules/pel/peltool/user_header.py
@@ -1,0 +1,70 @@
+from pel.datastream import DataStream
+from collections import OrderedDict
+from pel.peltool.pel_values import actionFlagsValues, subsystemValues, \
+    severityValues, eventTypeValues, eventScopeValues, transmissionStates
+from pel.peltool.comp_id import getDisplayCompID
+
+
+class UserHeader:
+    """
+    This represents the Private Header section in a PEL.  It is required,
+    and it is always the second section.
+
+    The Section base class handles the section header structure that every
+    PEL section has at offset zero.
+
+    The fields in this class directly correspond to the order and sizes of
+    the fields in the section.
+    """
+
+    def __init__(self, stream: DataStream, sectionID: int, sectionLen: int,
+                 versionID: int, subType: int, componentID: int, creatorID: str):
+        self.stream = stream
+        self.sectionID = sectionID
+        self.sectionLen = sectionLen
+        self.versionID = versionID
+        self.subType = subType
+        self.componentID = componentID
+        self.creatorID = creatorID
+        self.eventSubsystem = 0
+        self.eventScope = 0
+        self.eventSeverity = 0
+        self.eventType = 0
+        self.reserved4Byte1 = 0
+        self.problemDomain = 0
+        self.problemVector = 0
+        self.actionFlags = 0
+        self.states = 0
+
+    def toJSON(self) -> OrderedDict:
+        self.eventSubsystem = self.stream.get_int(1)
+        self.eventScope = self.stream.get_int(1)
+        self.eventSeverity = self.stream.get_int(1)
+        self.eventType = self.stream.get_int(1)
+        self.reserved4Byte1 = self.stream.get_int(4)
+        self.problemDomain = self.stream.get_int(1)
+        self.problemVector = self.stream.get_int(1)
+        self.actionFlags = self.stream.get_int(2)
+        self.states = self.stream.get_int(4)
+
+        list = []
+        for key in actionFlagsValues:
+            if key & self.actionFlags:
+                list.append(actionFlagsValues[key])
+
+        out = OrderedDict()
+        out["Section Version"] = self.versionID
+        out["Sub-section type"] = self.subType
+        out["Log Committed by"] = getDisplayCompID(
+            self.componentID, self.creatorID)
+        out["Subsystem"] = subsystemValues.get(self.eventSubsystem, 'Invalid')
+        out["Event Scope"] = eventScopeValues.get(self.eventScope, 'Invalid')
+        out["Event Severity"] = severityValues.get(self.eventSeverity, 'Invalid')
+        out["Event Type"] = eventTypeValues.get(self.eventType, 'Invalid')
+        out["Action Flags"] = list
+        out["Host Transmission"] = transmissionStates.get(
+            self.states & 0xff, 'Unknown')
+        out["HMC Transmission"] = transmissionStates.get(
+            (self.states & 0x0000FF00) >> 8, 'Unknown')
+
+        return out

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 
 setup(
     name        = "openpower-pel-parsers",
-    version     = "0.1",
+    version     = "1.0",
     classifiers = [ "License :: OSI Approved :: Apache Software License" ],
     packages    = find_packages("modules"),
-    package_dir = { "": "modules" },
+    package_dir = { "": "modules" }
 )


### PR DESCRIPTION
This is a python based PEL parser that outputs a PEL as JSON.  It uses
the same SRC and UserData plugin infrastructure as the original C++
based peltool.

It uses the 'pel_registry' module to find where the
message_registry.json and component name files are installed, though if
that isn't present, which it won't be on the BMC, it will look in the
BMC location which is /usr/share/phosphor-logging/pels/.  If it still
can't find it, it will just skip the SRC details and component names.

Invoke with:
$ python3 -m pel.peltool.peltool -f \<PEL file\>
$ python3 .../site-packages/pel/peltool/peltool.py -f \<PEL file\>

For now, it isn't installing peltool.py as a script into bin, since I
don't think I'm ready for all BMC users to know about it yet, which
they would if it was in the path along with the original peltool.

Signed-off-by: George Liu <liuxiwei@inspur.com>
Signed-off-by: Matt Spinler <spinler@us.ibm.com>