### PR TITLE
peltool: (non)serviceable PEL skipping

### DIFF
--- a/modules/pel/peltool/user_header.py
+++ b/modules/pel/peltool/user_header.py
@@ -36,6 +36,10 @@ class UserHeader:
         self.actionFlags = 0
         self.states = 0
 
+    def isServiceable(self) -> bool:
+        # consider it a serviceable PEL if not an info or recovered error
+        return self.eventSeverity != 0x00 and self.eventSeverity != 0x10
+
     def toJSON(self) -> OrderedDict:
         self.eventSubsystem = self.stream.get_int(1)
         self.eventScope = self.stream.get_int(1)
@@ -59,7 +63,8 @@ class UserHeader:
             self.componentID, self.creatorID)
         out["Subsystem"] = subsystemValues.get(self.eventSubsystem, 'Invalid')
         out["Event Scope"] = eventScopeValues.get(self.eventScope, 'Invalid')
-        out["Event Severity"] = severityValues.get(self.eventSeverity, 'Invalid')
+        out["Event Severity"] = severityValues.get(
+            self.eventSeverity, 'Invalid')
         out["Event Type"] = eventTypeValues.get(self.eventType, 'Invalid')
         out["Action Flags"] = list
         out["Host Transmission"] = transmissionStates.get(


### PR DESCRIPTION
Add options to peltool so it will just exit without printing anything
based on if the PEL is serviceable or not, where a serviceable PEL is
one with a severity that is neither informational or recovered.

This is for the case where a script is calling peltool on many PELs to
allow it to choose if it wants all PELs printed, or just serviceable or
nonserviceable ones.

-s: only print PEL if it's serviceable
-n: only print PEL if it's nonserviceable

Signed-off-by: Matt Spinler <spinler@us.ibm.com>