### PR TITLE
Check for package version from env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, find_packages
+import os
 
 setup(
     name        = "openpower-pel-parsers",
-    version     = "1.0",
+    version     = os.getenv('PELTOOL_VERSION', '1.0'),
     classifiers = [ "License :: OSI Approved :: Apache Software License" ],
     packages    = find_packages("modules"),
     package_dir = { "": "modules" }


### PR DESCRIPTION
In order to allow openpower-pel-parsers packages to have incrementing
versions without having to change the version manually every time the
code changes, check for the version to use in a PELTOOL_VERSION
environment variable.  If it isn't present, just use a default version
of 1.0.

The plan is that build tools will call setup.py with the env var set to
a version based on the tag of the openbmc build they are being pulled
into.

While it wouldn't be a huge deal to just increment a hardcoded version
in setup.py every time there's a code change, since code probably won't
change much, passing in the version allows people to know exactly which
level was used for the package.  Also, other packages used by peltool
change more often and there was a concern that manual version bumps
could be missed.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>