### PR TITLE
Update unit test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,18 @@ OpenPOWER PEL README.md (see link above).
 ## Testing
 
 It is highly encouraged to build and maintain automated test cases using the
-standard [unittest module](https://docs.python.org/3/library/unittest.html). All
-test modules should be stored in the `test/` directory (or subdirectory).
-Remember that all of the test files must be `modules` or `packages` importable
-from the top-level `test/` directory. To run all test cases in `test/`, issue
-the following command (at project root):
+standard [unittest module](https://docs.python.org/3/library/unittest.html).
+All test modules should be stored in the `test/` directory (or subdirectory).
+Remember that all of the test files must be `modules` or `packages`
+importable from the top-level `test/` directory, meaning all subdirectories
+must contain an `__init__.py` and the file names must be valid identifiers.
+
+To run all test cases in `test/`, issue the following commands:
 
 ```sh
-python3 -m unittest discover -s 'test/' -v
+cd modules/
+python3 -m unittest discover -v -s '../test/'
 ```
 
+**Reminder:** It is important that the above unittest command is run in the
+`modules` subdirectory. This ensures that `modules` is in the import path.

--- a/test/test_datastream.py
+++ b/test/test_datastream.py
@@ -1,7 +1,3 @@
-# Add the modules directory to the path.
-import os, sys
-sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'modules'))
-
 import unittest
 
 from pel.datastream import DataStream
@@ -36,5 +32,3 @@ class TestDataStream(unittest.TestCase):
         # attempt to access out of bounds
         with self.assertRaises(AssertionError):
             s.get_mem(1)
-
-

--- a/test/test_hwdiags_parserdata.py
+++ b/test/test_hwdiags_parserdata.py
@@ -1,7 +1,3 @@
-# Add the modules directory to the path.
-import os, sys
-sys.path.append(os.path.join(os.path.dirname(sys.path[0]), 'modules'))
-
 import unittest
 
 from collections import OrderedDict
@@ -53,14 +49,14 @@ class TestParserData(unittest.TestCase):
         self.assertEqual(data, exp_chip)
 
     def test_sig_data(self):
-        sig_id   = '5555'
+        sig_id = '5555'
         sig_inst = 0x66
-        sig_bit  = 0x77
+        sig_bit = 0x77
 
         data = self._parser.get_sig_desc(self._model_ec, sig_id, sig_inst,
                                          sig_bit)
 
-        exp_sig  = "id:%s(%d)[%s] " % (sig_id.upper(), sig_inst, sig_bit)
+        exp_sig = "id:%s(%d)[%s] " % (sig_id.upper(), sig_inst, sig_bit)
 
         self.assertEqual(data, exp_sig)
 
@@ -73,18 +69,18 @@ class TestParserData(unittest.TestCase):
 
         model_ec = word_a
 
-        chip_pos  = int(word_b[0:4], base=16)
-        node_pos  = int(word_b[4:6], base=16)
+        chip_pos = int(word_b[0:4], base=16)
+        node_pos = int(word_b[4:6], base=16)
         attn_type = int(word_b[6:8], base=16)
 
-        sig_id   =     word_c[0:4]
+        sig_id = word_c[0:4]
         sig_inst = int(word_c[4:6], base=16)
-        sig_bit  = int(word_c[6:8], base=16)
+        sig_bit = int(word_c[6:8], base=16)
 
         exp_chip = "node %d unknown %d (%s)" % (node_pos, chip_pos,
                                                 model_ec.upper())
 
-        exp_sig  = "id:%s(%d)[%s] " % (sig_id.upper(), sig_inst, sig_bit)
+        exp_sig = "id:%s(%d)[%s] " % (sig_id.upper(), sig_inst, sig_bit)
 
         exp_attn = str(attn_type)
 
@@ -94,4 +90,3 @@ class TestParserData(unittest.TestCase):
         expected["Attn Type"] = exp_attn
 
         self.assertEqual(data, expected)
-


### PR DESCRIPTION
The current instructions in the README.md requires that each test case
adds the `modules` directory to the import path. This can be avoided if
the unit test command is run from the `modules` directory.