### PR TITLE
IO Drawer: ILOG/PTE support

### DIFF
--- a/modules/udparsers/m2c00/ilog.py
+++ b/modules/udparsers/m2c00/ilog.py
@@ -1,0 +1,283 @@
+"""
+This module parses and formats ilog/PTE data.
+"""
+
+import re
+
+from pel.datastream import DataStream
+from udparsers.m2c00.utils import format_timestamp, get_header_file_path
+
+
+# Size in bytes of an ilog entry 
+ILOG_ENTRY_SIZE = 8
+
+# Mask to check if PTE is an error
+ERROR_MASK = 0xF0000000
+
+# Value after mask that indicates PTE is an error
+ERROR_VALUE = 0xE0000000
+
+# Mask to check if PTE has reported error flag on
+REPORTED_MASK = 0x00040000
+
+# Value after mask that indicates PTE has reported error flag on
+REPORTED_VALUE = 0x00040000
+
+
+# The following regular expressions describe lines from the C++ header file.
+# The header file defines a table of PTE entries.
+
+# Regex for line that starts the table.  Opening brace could be on this line or
+# the next one.
+#
+# Example:
+#   struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = 
+TBL_START_RE = re.compile(r'\s*struct\s+pte_entry_struct\s+'
+                           'static_pte_entry_table.*\=\s*\{?\s*')
+
+# Regex for line that defines one table entry.  The message format field is a
+# string surrounded by double quotes, but it can also contain escaped double
+# quotes.  The params field is an array of integers; a list of zero or more
+# comma-delimited numbers surrounded by braces.
+#
+# Examples:
+#   { "01040000", "Power on complete", {}, "states.cpp", 601 },
+#   { "100100**", "PS%d - Faults Cleared", {4}, "mps.cpp", 759 },
+#   { "0200****", "This PEROM level = %c%c", {3, 4}, "states.cpp", 254 },
+#   { "E2082690", "P1 IO Bay VRM in \"N-Mode\"", {}, "vrm_monitor.cpp", 145 },
+TBL_ENTRY_RE = re.compile(r'\s*\{\s*"([^"]+)"\s*\,\s*"((?:[^"]|\\")*)"\s*'
+                           '\,\s*\{([^}]*)\}\s*\,\s*"([^"]*)"\s*\,\s*'
+                           '([0-9]+)\s*\}\s*\,\s*')
+
+# Regex for line that ends the table.  It is an empty table entry.  In Python
+# '.*' does not by default match newline, so the regex ends with '\s*'.
+#
+# Example:
+#   { ""        , "The End" }
+TBL_END_RE = re.compile(r'\s*\{\s*""\s*\,\s*"The End".*\s*')
+
+
+class PTETableEntry:
+    """
+    Represents one entry in the PTE table from the C++ header file.
+    """
+
+    def __init__(self, pte_pattern: str, message_format: str, params: tuple,
+                 file: str, line: int):
+        """
+        Constructor.
+        """
+
+        self.pte_pattern = pte_pattern
+        self.message_format = message_format
+        self.params = params
+        self.file = file
+        self.line = line
+
+        # Discard any parameters outside the valid range 1-4.  The parameters
+        # are 1-based byte numbers within a PTE that provide the values to use
+        # in the message format string.  A PTE is 4 bytes long.
+        self.params = tuple(p for p in self.params if (p >= 1) and (p <= 4))
+
+        # Compile regular expression corresponding to pte_pattern.  pte_pattern
+        # is not in regular expression format.  It contains '*' characters to
+        # match any one character.  Convert '*' to '.'.
+        re_pattern = self.pte_pattern.replace('*', '.')
+        self.pte_re = re.compile(re_pattern, re.IGNORECASE)
+
+    def get_message(self, pte: int) -> str:
+        """
+        Returns a formatted message for the specified PTE.
+
+        The PTE should be a 4 byte, unsigned integer value.
+
+        If the message contains parameters, this method obtains the parameter
+        values from the PTE bytes.
+        """
+
+        # Build list of 4 bytes in the PTE
+        pte_bytes = list((pte & 0xFFFFFFFF).to_bytes(4, 'big'))
+
+        # Get parameter values from PTE bytes.  Note that parameter numbers are
+        # 1-based, so we need to subtract 1 for byte indices.
+        param_values = tuple(pte_bytes[p - 1] for p in self.params)
+
+        # Format the message using the parameter values (if any)
+        try:
+            message = self.message_format % param_values
+        except Exception:
+            message = self.message_format
+
+        # Add suffix to message if PTE indicates it is a reported error
+        if self._is_reported_error_pte(pte):
+            message += ' - PEL entry created'
+
+        return message
+    
+    def matches(self, pte: int) -> bool:
+        """
+        Returns whether the specified PTE matches this table entry.
+        """
+
+        # Check for an exact match
+        if self._is_exact_match(pte):
+            return True
+
+        # Check if the PTE is an error that has been reported.  If so, remove
+        # the reported flag and check again for a match.
+        if self._is_reported_error_pte(pte):
+            pte &= ~REPORTED_MASK
+            if self._is_exact_match(pte):
+                return True
+
+        return False
+
+    def _is_exact_match(self, pte: int) -> bool:
+        """
+        Returns whether the specified PTE matches the regular expression for
+        this table entry.
+        """
+
+        hex_string = f'{pte:08X}'
+        match = self.pte_re.fullmatch(hex_string)
+        return match is not None
+
+    def _is_reported_error_pte(self, pte: int) -> bool:
+        """
+        Returns whether the specified PTE is a reported error.
+        """
+
+        return (((pte & ERROR_MASK) == ERROR_VALUE) and
+                ((pte & REPORTED_MASK) == REPORTED_VALUE))
+
+
+class PTETable:
+    """
+    Represents the PTE table defined in the C++ header file.
+    """
+
+    def __init__(self, header_file_path: str = None):
+        """
+        Constructor.
+
+        Parses the specified C++ header file to obtain the PTE table.
+
+        If the header file path is not specified, it will be found in
+        the standard location.
+        """
+
+        self.header_file_path = header_file_path
+        self.entries = []
+
+        # Find header file path if not specified
+        if not self.header_file_path:
+            self.header_file_path = get_header_file_path()
+
+        # Parse header file to get PTE table
+        self._parse_header_file()
+
+    def get_entry(self, pte: int) -> PTETableEntry:
+        """
+        Returns the table entry that matches the specified PTE.
+
+        Returns None if no matching entry is found.
+        """
+
+        for entry in self.entries:
+            if entry.matches(pte):
+                return entry
+        return None
+
+    def _add_entry(self, fields: tuple):
+        """
+        Creates a table entry based on the specified fields from the C++ header
+        file.
+        """
+
+        # Verify we have the right number of fields
+        if len(fields) != 5:
+            return
+
+        # Obtain entry properties from the string values in the fields tuple.
+        # Example:
+        #   ('0200****', 'PEROM level = %c%c  ', '3, 4', 'states.cpp', '254')
+        pte_pattern = fields[0]
+        message_format = fields[1]
+        params_str = fields[2]
+        file = fields[3]
+        line = int(fields[4])
+
+        # Remove leading/trailing blanks from message format string and replace
+        # escaped double quotes with plain double quotes
+        message_format = message_format.strip().replace(r'\"', '"')
+
+        # Convert string with list of parameters into tuple of numbers.
+        # Example: '3, 4' -> (3, 4)
+        params = tuple(int(p) for p in params_str if p.isdecimal())
+
+        # Create entry and add to list of entries
+        entry = PTETableEntry(pte_pattern, message_format, params, file, line)
+        self.entries.append(entry)
+
+    def _parse_header_file(self):
+        """
+        Parses the C++ header file to get the PTE table.
+        """
+
+        in_table = False
+        with open(self.header_file_path) as file:
+            for line in file:
+                if TBL_START_RE.fullmatch(line):
+                    in_table = True
+                elif TBL_END_RE.fullmatch(line):
+                    in_table = False
+                elif in_table:
+                    match = TBL_ENTRY_RE.fullmatch(line)
+                    if match:
+                        self._add_entry(match.groups())
+
+
+def parse_ilog_data(data: memoryview,
+                    header_file_path: str = None) -> list:
+    """
+    Parses binary ilog/PTE data and returns formatted output.
+
+    Parses the specified C++ header file to obtain the PTE table.
+
+    If the header file path is not specified, it will be found in the
+    standard location.
+    """
+
+    # Get PTE Table from C++ header file
+    table = PTETable(header_file_path)
+
+    # Add ilog table header to output lines
+    lines = []
+    lines.append('hh:mm:ss seq  pppppppp description')
+    lines.append('-------- ---- -------- ------------------------------------')
+
+    # Loop over the data bytes
+    stream = DataStream(data, byte_order='big', is_signed=False)
+    while stream.check_range(ILOG_ENTRY_SIZE):
+        # Parse ilog entry fields
+        timestamp = stream.get_int(2)
+        seq_num = stream.get_int(2)
+        pte = stream.get_int(4)
+
+        # Ignore invalid ilog entries
+        if (timestamp == 0) and (seq_num == 0) and (pte == 0x00000000):
+            continue
+
+        # Format timestamp value
+        timestamp_str = format_timestamp(timestamp)
+
+        # Get entry from table that matches PTE.  Then get message from entry.
+        message = 'Undefined'
+        entry = table.get_entry(pte)
+        if entry is not None:
+            message = entry.get_message(pte)
+
+        # Add output line for ilog entry
+        lines.append(f'{timestamp_str} {seq_num:04X} {pte:08X} {message}')
+
+    return lines

--- a/modules/udparsers/m2c00/utils.py
+++ b/modules/udparsers/m2c00/utils.py
@@ -5,7 +5,28 @@ This module contains shared utility functions.
 import os
 
 
-def get_header_file_path():
+def format_timestamp(timestamp: int) -> str:
+    """
+    Converts the specified two-byte, unsigned integer timestamp to a
+    string.
+
+    Returns the formatted string.  Uses the format HH:MM:SS.
+
+    Note: the timestamp is NOT correlated to real world time.  It is a simple
+    second counter that rolls over at 0xFFFF.
+    """
+
+    # Verify timestamp is valid
+    if (timestamp < 0) or (timestamp >= 0xFFFF):
+        return '--------'
+
+    hh = timestamp // 3600
+    mm = (timestamp - (hh*3600)) // 60
+    ss = timestamp - (hh*3600) - (mm*60)
+    return f'{hh:2d}:{mm:02d}:{ss:02d}'
+
+
+def get_header_file_path() -> str:
     """
     Returns the path to the C++ header file that contains ilog and
     history log definitions.

--- a/test/test_udparsers/m2c00/test_ilog.py
+++ b/test/test_udparsers/m2c00/test_ilog.py
@@ -1,0 +1,482 @@
+import os
+import re
+import tempfile
+import unittest
+
+from udparsers.m2c00.ilog import PTETableEntry, PTETable, parse_ilog_data
+
+
+class TestILogBase(unittest.TestCase):
+    """
+    Base class for unit tests for the ilog module.
+
+    Contains shared setUp/tearDown code and utility methods.
+    """
+
+    def setUp(self):
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        tmp_file.close()
+        self.header_file_path = tmp_file.name
+
+    def tearDown(self):
+        os.remove(self.header_file_path)
+
+    def _assertEntry(self, entry: PTETableEntry, pte_pattern: str,
+                     message_format: str, params: tuple, file: str, line: int,
+                     re_pattern: str):
+        self.assertEqual(entry.pte_pattern, pte_pattern)
+        self.assertEqual(entry.message_format, message_format)
+        self.assertEqual(entry.params, params)
+        self.assertEqual(entry.file, file)
+        self.assertEqual(entry.line, line)
+        self.assertEqual(entry.pte_re.pattern, re_pattern)
+        self.assertTrue((entry.pte_re.flags & re.IGNORECASE) != 0)
+
+    def _create_header_file(self, lines: list):
+        with open(self.header_file_path, 'w') as file:
+            for line in lines:
+                file.write(line)
+                file.write('\n')
+
+
+class TestPTETableEntry(TestILogBase):
+    """
+    Unit tests for the PTETableEntry class.
+    """
+
+    def test__init__(self):
+        # No wildcard in PTE pattern, no parameters
+        entry = PTETableEntry('15A00000',
+                              'Bad non-volatile storage count offset',
+                              (), 'nvs.cpp', 1001)
+        self._assertEntry(entry, '15A00000',
+                          'Bad non-volatile storage count offset',
+                          (), 'nvs.cpp', 1001, '15A00000')
+
+        # One wildcard in PTE pattern, one parameter
+        entry = PTETableEntry('010000**',
+                              'Begin power on, node type = 0x%02X',
+                              (4,), 'states.cpp', 485)
+        self._assertEntry(entry, '010000**',
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+
+        # Two wildcards in PTE pattern, two parameters
+        entry = PTETableEntry('0210****',
+                              'Code level date stamp:  month %x, day %x',
+                              (3, 4), 'elog.cpp', 863)
+        self._assertEntry(entry, '0210****',
+                          'Code level date stamp:  month %x, day %x',
+                          (3, 4), 'elog.cpp', 863, '0210....')
+
+        # One invalid parameter: < 1: Verify removed
+        entry = PTETableEntry('0210****',
+                              'Code level date stamp:  month %x, day %x',
+                              (0, 4), 'elog.cpp', 863)
+        self.assertEqual(entry.params, (4,))
+
+        # One invalid parameter: > 4: Verify removed
+        entry = PTETableEntry('0210****',
+                              'Code level date stamp:  month %x, day %x',
+                              (1, 5), 'elog.cpp', 863)
+        self.assertEqual(entry.params, (1,))
+
+        # All parameters invalid: Verify all removed
+        entry = PTETableEntry('0210****',
+                              'Code level date stamp:  month %x, day %x',
+                              (-1, 99), 'elog.cpp', 863)
+        self.assertEqual(entry.params, ())
+
+    def test_get_message(self):
+        # No parameters
+        entry = PTETableEntry('01430000',
+                              'New IO bay detected on power on.',
+                              (), 'states.cpp', 380)
+        msg = entry.get_message(0x01430000)
+        self.assertEqual(msg, 'New IO bay detected on power on.')
+
+        # One parameter and use of %d
+        entry = PTETableEntry('0143**00',
+                              'New IO bay %d detected on power on.',
+                              (3,), 'states.cpp', 445)
+        msg = entry.get_message(0x01430100)
+        self.assertEqual(msg, 'New IO bay 1 detected on power on.')
+
+        # Two parameters and use of %c
+        entry = PTETableEntry('0200****',
+                              'This PEROM level = %c%c',
+                              (3, 4), 'states.cpp', 254)
+        msg = entry.get_message(0x02004445)
+        self.assertEqual(msg, 'This PEROM level = DE')
+
+        # Two parameters in descending order and use of %X
+        entry = PTETableEntry('0200****',
+                              'This PEROM level = 0x%02X%02X',
+                              (4, 3), 'states.cpp', 254)
+        msg = entry.get_message(0x0200DEAD)
+        self.assertEqual(msg, 'This PEROM level = 0xADDE')
+
+        # Too few parameters for message format string
+        entry = PTETableEntry('0200****',
+                              'This PEROM level = 0x%02X%02X',
+                              (4,), 'states.cpp', 254)
+        msg = entry.get_message(0x0200DEAD)
+        self.assertEqual(msg, 'This PEROM level = 0x%02X%02X')
+
+        # Too many parameters for message format string
+        entry = PTETableEntry('0143**00',
+                              'New IO bay %d detected on power on.',
+                              (3, 4), 'states.cpp', 445)
+        msg = entry.get_message(0x01430100)
+        self.assertEqual(msg, 'New IO bay %d detected on power on.')
+
+        # Not a reported error: No suffix added
+        entry = PTETableEntry('15A40000',
+                              'Bad non-volatile storage count offset',
+                              (), 'nvs.cpp', 1001)
+        msg = entry.get_message(0x15A40000)
+        self.assertEqual(msg, 'Bad non-volatile storage count offset')
+
+        # Reported error: Adds suffix for PEL entry creation
+        entry = PTETableEntry('E3087704',
+                              'Fan Missing - System Fan 1',
+                              (), 'sys_fan.cpp', 191)
+        msg = entry.get_message(0xE30C7704)
+        self.assertEqual(msg, 'Fan Missing - System Fan 1 - PEL entry created')
+
+    def test_matches(self):
+        # Exact match
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry.matches(0xE3087704))
+
+        # Matches after removing reported error flag
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry.matches(0xE30C7704))
+
+        # Doesn't match
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertFalse(entry.matches(0xE3087705))
+
+    def test__is_exact_match(self):
+        # Matches: No wildcard in PTE pattern
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry._is_exact_match(0xE3087704))
+
+        # Matches: One wildcard in PTE pattern
+        entry = PTETableEntry('E30877**', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry._is_exact_match(0xE30877AE))
+
+        # Matches: Two wildcards in PTE pattern
+        entry = PTETableEntry('E308****', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry._is_exact_match(0xE30823AE))
+
+        # Doesn't match: No wildcard in PTE pattern
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertFalse(entry._is_exact_match(0xE3087705))
+
+        # Doesn't match: One wildcard in PTE pattern
+        entry = PTETableEntry('E30877**', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertFalse(entry._is_exact_match(0xE40877AE))
+
+        # Doesn't match: Two wildcards in PTE pattern
+        entry = PTETableEntry('E308****', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertFalse(entry._is_exact_match(0xE30A23AE))
+
+    def test__is_reported_error_pte(self):
+        # Not a reported error: First PTE byte is not 0xE*
+        entry = PTETableEntry('15A40000', 'Bad NVS', (), 'nvs.cpp', 1001)
+        self.assertFalse(entry._is_reported_error_pte(0x15A40000))
+
+        # Not a reported error: Second PTE byte doesn't have reported flag 0x04
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertFalse(entry._is_reported_error_pte(0xE3087704))
+
+        # Reported error
+        entry = PTETableEntry('E3087704', 'Fan Missing', (), 'sys_fan.cpp', 191)
+        self.assertTrue(entry._is_reported_error_pte(0xE30C7704))
+
+
+class TestPTETable(TestILogBase):
+    """
+    Unit tests for the PTETable class.
+    """
+
+    def test__init__(self):
+		# Test with real header file generated during firmware build
+        table = PTETable()
+        self.assertTrue(os.path.exists(table.header_file_path))
+        self.assertEqual(os.path.basename(table.header_file_path), 'mex_pte.h')
+        self.assertTrue(len(table.entries) > 600)
+
+        # Test with dummy header file: Standard C++ format
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = ',
+            '{',
+            '  { "010000**", "Begin power on, node type = 0x%02X", {4}, "states.cpp", 485 },',
+            '  { "01040000", "Power on complete", {}, "states2.cpp", 601 },',
+            '  { ""        , "The End" }',
+            '};'
+        ])
+        table = PTETable(self.header_file_path)
+        self.assertEqual(table.header_file_path, self.header_file_path)
+        self.assertEqual(len(table.entries), 2)
+        self._assertEntry(table.entries[0], '010000**', 
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+        self._assertEntry(table.entries[1], '01040000', 
+                          'Power on complete',
+                          (), 'states2.cpp', 601, '01040000')
+
+        # Test where header file does not exist
+        with self.assertRaises(Exception):
+            table = PTETable('/does_not_exist/dne/mex_pte.h')
+
+    def test_get_entry(self):
+        # Create dummy header file and load into PTE table
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = ',
+            '{',
+            '  { "0101****", "Fan presence 0x%02X, flash = %c", {4, 3}, "fan.cpp", 530 },',
+            '  { "01040000", "Power on complete", {}, "states2.cpp", 601 },',
+            '  { ""        , "The End" }',
+            '};'
+        ])
+        table = PTETable(self.header_file_path)
+
+        # Test where matching entry is found: No wildcards in PTE pattern
+        self.assertIsNotNone(table.get_entry(0x01040000))
+
+        # Test where matching entry is found: Wildcards in PTE pattern
+        self.assertIsNotNone(table.get_entry(0x0101BEEF))
+
+        # Test where matching entry is not found
+        self.assertIsNone(table.get_entry(0x0102BEEF))
+
+    def test__add_entry(self):
+        # Create empty header file and empty PTE table
+        self._create_header_file([''])
+        table = PTETable(self.header_file_path)
+        self.assertEqual(len(table.entries), 0)
+
+        # Add entry with no PTE wildcards and 0 parameters
+        table._add_entry(('01040000', 'Power on complete',
+                          '', 'states.cpp', '601'))
+        self.assertEqual(len(table.entries), 1)
+        self._assertEntry(table.entries[0], '01040000', 
+                          'Power on complete',
+                          (), 'states.cpp', 601, '01040000')
+
+        # Add entry with PTE wildcards, 1 parameter, and trailing whitespace in
+        # message format field
+        table._add_entry(('100100**', 'PS%d - Faults Cleared    ',
+                          ' 4 ', 'mps.cpp', '759'))
+        self.assertEqual(len(table.entries), 2)
+        self._assertEntry(table.entries[1], '100100**', 
+                          'PS%d - Faults Cleared',
+                          (4,), 'mps.cpp', 759, '100100..')
+
+        # Add entry with PTE wildcards and 2 parameters
+        table._add_entry(('2065****', 'IO Bay %d type = %d',
+                          ' 3 , 4 ', 'vpd_col.cpp', '2635'))
+        self.assertEqual(len(table.entries), 3)
+        self._assertEntry(table.entries[2], '2065****', 
+                          'IO Bay %d type = %d',
+                          (3, 4), 'vpd_col.cpp', 2635, '2065....')
+
+        # Add entry with escaped double quotes
+        table._add_entry(('E2082690', r'P1 IO Bay VRM in \"N-Mode\" ',
+                          '', 'vrm_monitor.cpp', '145'))
+        self.assertEqual(len(table.entries), 4)
+        self._assertEntry(table.entries[3], 'E2082690', 
+                          'P1 IO Bay VRM in "N-Mode"',
+                          (), 'vrm_monitor.cpp', 145, 'E2082690')
+
+        # Specify invalid number of fields (4).  Should return without adding a
+        # new entry.
+        table._add_entry(('15D10000', 'POP non-volatile storage update',
+                          '', 'nvs.cpp'))
+        self.assertEqual(len(table.entries), 4)
+
+    def test__parse_header_file(self):
+		# Test with real header file generated during firmware build
+        table = PTETable()
+        table.entries = []
+        table._parse_header_file()
+        self.assertTrue(len(table.entries) > 600)
+
+        # Test with dummy header file: Standard C++ format
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = ',
+            '{',
+            '  { "010000**", "Begin power on, node type = 0x%02X", {4}, "states.cpp", 485 },',
+            '  { "0101****", "Fan presence 0x%02X, flash = %c", {4, 3}, "fan.cpp", 530 },',
+            '  { "01040000", "Power on complete", {}, "states2.cpp", 601 },',
+            '  // The following must be the last entry',
+            '  { ""        , "The End" }',
+            '};'
+        ])
+        table.header_file_path = self.header_file_path
+        table.entries = []
+        table._parse_header_file()
+        self.assertEqual(len(table.entries), 3)
+        self._assertEntry(table.entries[0], '010000**', 
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+        self._assertEntry(table.entries[1], '0101****', 
+                          'Fan presence 0x%02X, flash = %c',
+                          (4, 3), 'fan.cpp', 530, '0101....')
+        self._assertEntry(table.entries[2], '01040000', 
+                          'Power on complete',
+                          (), 'states2.cpp', 601, '01040000')
+
+        # Test with dummy header file: Extra white space
+        self._create_header_file([
+            ' struct  pte_entry_struct  static_pte_entry_table [ PTE_TABLE_SIZE ] =   ',
+            ' { ',
+            '  {  "010000**" , "Begin power on, node type = 0x%02X  " , { 4 } , "states.cpp" , 485 } , ',
+            '  {  "0101****" , "Fan presence 0x%02X, flash = %c  " , { 4 , 3 } , "fan.cpp" , 530 } , ',
+            '  {  "01040000" , "  Power on complete  " , {  } , "states2.cpp" , 601 } , ',
+            '  {  ""        ,  "The End"  }  ',
+            '  }  ;'
+        ])
+        table.entries = []
+        table._parse_header_file()
+        self.assertEqual(len(table.entries), 3)
+        self._assertEntry(table.entries[0], '010000**', 
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+        self._assertEntry(table.entries[1], '0101****', 
+                          'Fan presence 0x%02X, flash = %c',
+                          (4, 3), 'fan.cpp', 530, '0101....')
+        self._assertEntry(table.entries[2], '01040000', 
+                          'Power on complete',
+                          (), 'states2.cpp', 601, '01040000')
+
+        # Test with dummy header file: Minimal white space
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[]={',
+            '{"010000**","Begin power on, node type = 0x%02X",{4},"states.cpp",485},',
+            '{"0101****","Fan presence 0x%02X, flash = %c",{4,3},"fan.cpp",530},',
+            '{"01040000","Power on complete",{},"states2.cpp",601},',
+            '{"","The End"}',
+            '};'
+        ])
+        table.entries = []
+        table._parse_header_file()
+        self.assertEqual(len(table.entries), 3)
+        self._assertEntry(table.entries[0], '010000**', 
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+        self._assertEntry(table.entries[1], '0101****', 
+                          'Fan presence 0x%02X, flash = %c',
+                          (4, 3), 'fan.cpp', 530, '0101....')
+        self._assertEntry(table.entries[2], '01040000', 
+                          'Power on complete',
+                          (), 'states2.cpp', 601, '01040000')
+
+        # Test with dummy header file: Invalid lines and escaped double quotes
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = ',
+            '  ',
+            '{',
+            '  // State PTEs',
+            '  { "010000**", "Begin power on, node type = 0x%02X", {4}, "states.cpp", 485 },',
+            '  ',
+            '  // { "0101****", "Fan presence 0x%02X, flash = %c", {4, 3}, "fan.cpp", 530 },',
+           r'  { "E2082690", "P1 IO Bay VRM in \"N-Mode\" ", {}, "vrm_monitor.cpp", 145 },',
+            '  { "01040000", "Power on complete", {}, "states2.cpp", 601 },',
+            '  // The following must be the last entry',
+            '  ',
+            '  { ""        , "The End" }',
+            '  ',
+            '};'
+        ])
+        table.entries = []
+        table._parse_header_file()
+        self.assertEqual(len(table.entries), 3)
+        self._assertEntry(table.entries[0], '010000**', 
+                          'Begin power on, node type = 0x%02X',
+                          (4,), 'states.cpp', 485, '010000..')
+        self._assertEntry(table.entries[1], 'E2082690', 
+                          'P1 IO Bay VRM in "N-Mode"',
+                          (), 'vrm_monitor.cpp', 145, 'E2082690')
+        self._assertEntry(table.entries[2], '01040000', 
+                          'Power on complete',
+                          (), 'states2.cpp', 601, '01040000')
+
+        # Test where header file does not exist
+        table.header_file_path = '/does_not_exist/dne/mex_pte.h'
+        with self.assertRaises(Exception):
+            table._parse_header_file()
+
+
+class TestILog(TestILogBase):
+    """
+    Unit tests for functions in the ilog module.
+    """
+
+    def test_parse_ilog_data(self):
+		# Test with real header file generated during firmware build
+        data = memoryview(                      # ILOG entry 1
+                          b'\x8A\xDF'           #   timestamp
+                          b'\x0F\x19'           #   seq_num
+                          b'\x01\x00\x00\xDE'   #   pte (010000**)
+                                                # ILOG entry 2
+                          b'\x8D\x47'           #   timestamp
+                          b'\x10\x24'           #   seq_num
+                          b'\x01\x04\x00\x00')  #   pte (01040000)
+        lines = parse_ilog_data(data)
+        expected_lines = [
+            'hh:mm:ss seq  pppppppp description',
+            '-------- ---- -------- ------------------------------------',
+            ' 9:52:31 0F19 010000DE Begin power on, node type = 0xDE',
+            '10:02:47 1024 01040000 Power on complete',
+        ]
+        self.assertEqual(lines, expected_lines)
+
+        # Test with dummy header file.  Verify ignores ILOG entry with all
+        # fields set to 0.  Test where PTE is undefined (not found in table).
+        # Test where the last ILOG entry is truncated.
+        self._create_header_file([
+            'struct pte_entry_struct static_pte_entry_table[PTE_TABLE_SIZE] = ',
+            '{',
+            '  { "010000**", "Begin power on, node type = 0x%02X", {4}, "states.cpp", 485 },',
+            '  { "0101****", "Fan presence 0x%02X, flash = %c", {4, 3}, "fan.cpp", 530 },',
+            '  { "01040000", "Power on complete", {}, "states2.cpp", 601 },',
+            '  { ""        , "The End" }',
+            '};'
+        ])
+        data = memoryview(                      # ILOG entry 1 - all zeros
+                          b'\x00\x00'           #   timestamp
+                          b'\x00\x00'           #   seq_num
+                          b'\x00\x00\x00\x00'   #   pte
+                                                # ILOG entry 2
+                          b'\x8D\x47'           #   timestamp
+                          b'\xDE\xAD'           #   seq_num
+                          b'\x01\x00\x00\x03'   #   pte (010000**)
+                                                # ILOG entry 3 - undefined PTE
+                          b'\x8D\xD4'           #   timestamp
+                          b'\xDF\x98'           #   seq_num
+                          b'\x01\x02\x00\x03'   #   pte
+                                                # ILOG entry 4
+                          b'\x8D\xE3'           #   timestamp
+                          b'\xDF\xA0'           #   seq_num
+                          b'\x01\x01\x44\xEF'   #   pte (0101****)
+                                                # ILOG entry 5
+                          b'\x8D\xF1'           #   timestamp
+                          b'\xDF\xA7'           #   seq_num
+                          b'\x01\x04\x00\x00'   #   pte (01040000)
+                                                # ILOG entry 6 - truncated
+                          b'\x8D\xF9'           #   timestamp
+                          b'\xDF\xAC'           #   seq_num
+                          b'\x01\x02\x00')      #   pte
+        lines = parse_ilog_data(data, self.header_file_path)
+        expected_lines = [
+            'hh:mm:ss seq  pppppppp description',
+            '-------- ---- -------- ------------------------------------',
+            '10:02:47 DEAD 01000003 Begin power on, node type = 0x03',
+            '10:05:08 DF98 01020003 Undefined',
+            '10:05:23 DFA0 010144EF Fan presence 0xEF, flash = D',
+            '10:05:37 DFA7 01040000 Power on complete',
+        ]
+        self.assertEqual(lines, expected_lines)

--- a/test/test_udparsers/m2c00/test_utils.py
+++ b/test/test_udparsers/m2c00/test_utils.py
@@ -1,10 +1,26 @@
 import os
 import unittest
 
-from udparsers.m2c00.utils import get_header_file_path
+from udparsers.m2c00.utils import format_timestamp, get_header_file_path
 
 
 class TestUtils(unittest.TestCase):
+
+    def test_format_timestamp(self):
+        # Test with valid timestamps
+        self.assertEqual(format_timestamp(0x0000), ' 0:00:00')
+        self.assertEqual(format_timestamp(0x0005), ' 0:00:05')
+        self.assertEqual(format_timestamp(0x003C), ' 0:01:00')
+        self.assertEqual(format_timestamp(0x005B), ' 0:01:31')
+        self.assertEqual(format_timestamp(0x0313), ' 0:13:07')
+        self.assertEqual(format_timestamp(0x1960), ' 1:48:16')
+        self.assertEqual(format_timestamp(0x473E), ' 5:03:58')
+        self.assertEqual(format_timestamp(0xFFFE), '18:12:14')
+
+        # Test with invalid timestamps
+        self.assertEqual(format_timestamp(-1), '--------')
+        self.assertEqual(format_timestamp(0xFFFF), '--------')
+        self.assertEqual(format_timestamp(0x10000), '--------')
 
     def test_get_header_file_path(self):
         path = get_header_file_path()


### PR DESCRIPTION
Add support for parsing and formatting the ilog/PTE data produced by an
I/O drawer.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>