### PR TITLE
IO Drawer: Update setup.py due to data file move

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     classifiers  = [ "License :: OSI Approved :: Apache Software License" ],
     packages     = find_packages("modules"),
     package_dir  = { "": "modules" },
-    package_data = { "udparsers.m2c00": [ "mex_pte.h", "mexStringFile" ] }
+    package_data = { "io_drawer": [ "mex_pte.h", "mexStringFile" ] }
 )


### PR DESCRIPTION
Two data files used by the IO drawer error log plugin were moved to a
different module/directory.

Update the setup.py file so the files are installed from the new
module/directory.

Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>