### PR TITLE
Add peltool-wrapper package

### DIFF
--- a/peltool-wrapper/setup.py
+++ b/peltool-wrapper/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup
+import os
+
+# This package is just used to install all of the component peltool
+# packages and doesn't contain any code of its own.
+
+version = os.getenv('PELTOOL_VERSION', '0.1')
+
+setup(
+    name        = "peltool-wrapper",
+    version     = f'{version}',
+    classifiers = [ "License :: OSI Approved :: Apache Software License" ],
+    packages = ['peltool-wrapper'],
+    install_requires = [
+        f"openpower-pel-parsers >= {version}",
+        f"Hostboot >= {version}",
+        f"sbe-pel-parser >= {version}",
+        f"pel-message-registry >= {version}",
+        f"openpower-hw-diags-pel-parser-data >= {version}"
+        ]
+)


### PR DESCRIPTION
This will just be used to install the actual python packages that make
up peltool so that a single install command can be used to install (and
upgrade, I think) everything, especially when installing from the
artifactory.

Bitbake will not be told about this setup.py, so it will not be
installed on the BMC itself.  The plan is to update the scripts in the
ibm-build-scripts repo in GHE to build it and push it out to the
artifactory after each build, though for now I may just push it out
there manually.

If the PELTOOL_VERSION env var is present, that will also be the minimum
version required of the component packages, otherwise it will default to
the minimum version 0.1. Pip will always installed the newest version it
can find anyway.

For example, with ~/.pip/pip.conf pointing at the artifactory:

$ pip3 install peltool_wrapper-0.1-py3-none-any.whl
Looking in indexes: https://pypi.org/simple, https://spinler%40us.ibm.com:****@na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/simple
Processing ./peltool_wrapper-0.1-py3-none-any.whl
Collecting Hostboot>=0.1
  Using cached https://na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/Hostboot/1.1030.0.2.1/Hostboot-1.1030.0.2.1-py3-none-any.whl (382 kB)
Collecting openpower-pel-parsers>=0.1
  Using cached https://na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/openpower-pel-parsers/1.1030.0.2.1/openpower_pel_parsers-1.1030.0.2.1-py3-none-any.whl (70 kB)
Collecting sbe-pel-parser>=0.1
  Using cached https://na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/sbe-pel-parser/1.1030.0.2.1/sbe_pel_parser-1.1030.0.2.1-py3-none-any.whl (13 kB)
Collecting pel-message-registry>=0.1
  Using cached https://na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/pel-message-registry/1.1030.0.2.1/pel_message_registry-1.1030.0.2.1-py3-none-any.whl (17 kB)
Collecting openpower-hw-diags-pel-parser-data>=0.1
  Using cached https://na.artifactory.swg-devops.com/artifactory/api/pypi/sys-pwr-aoa-team-bin-pytools-pypi-local/openpower-hw-diags-pel-parser-data/1.1030.0.2.1/openpower_hw_diags_pel_parser_data-1.1030.0.2.1-py3-none-any.whl (95 kB)
Installing collected packages: sbe-pel-parser, pel-message-registry, openpower-pel-parsers, openpower-hw-diags-pel-parser-data, Hostboot, peltool-wrapper
Successfully installed Hostboot-1.1030.0.2.1 openpower-hw-diags-pel-parser-data-1.1030.0.2.1 openpower-pel-parsers-1.1030.0.2.1 pel-message-registry-1.1030.0.2.1 peltool-wrapper-0.1 sbe-pel-parser-1.1030.0.2.1

Signed-off-by: Matt Spinler <spinler@us.ibm.com>