### PR TITLE
Fix type hint in parse_user_data.py

### DIFF
--- a/modules/pel/peltool/parse_user_data.py
+++ b/modules/pel/peltool/parse_user_data.py
@@ -22,7 +22,7 @@ class ParseUserData:
     ExtUserData sections.
     """
 
-    def __init__(self, creatorID: str, compID: str, subType: int, version: int,
+    def __init__(self, creatorID: str, compID: int, subType: int, version: int,
                  data: bytes):
         self.creatorID = creatorID
         self.compID = compID


### PR DESCRIPTION
The compID variable is really an integer and not a string, so fix that
in the __init__() parameter list that specifies it.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>