### PR TITLE
peltool: add new procedure description for failed parts present

### DIFF
--- a/modules/calloutparsers/ocallouts/ocallouts.py
+++ b/modules/calloutparsers/ocallouts/ocallouts.py
@@ -31,6 +31,10 @@ procedures = {
     "BMC0007": [
         "A system data mismatch has been detected."
     ]
+
+    "BMC0008": [
+        "Failed parts present in the system. Service needed"
+    ]
 }
 
 


### PR DESCRIPTION
On the IBM OpenPOWER systems, event logs and hardware isolation records are created after encountering a hardware failure. These records will be resolved once the repair action is performed. However, in certain situations, the service engineer or customer can defer the service action for some of the failures. In such cases, there are chances to miss such failure records, and the system may fail unexpectedly, causing undesirable impacts. This problem is overcome by sending periodic error events to remind about the failed parts present in the system

added new procedure that gets logged when failed parts are present in the system


Change-Id: Ifc743d6bd9441c67ff7266c55ffd094577784e35