### PR TITLE
Slightly modify default hexdump format

### DIFF
--- a/modules/pel/hexdump.py
+++ b/modules/pel/hexdump.py
@@ -32,7 +32,7 @@ def hexdump(data: memoryview,
 
             # Add spaces in between each chunk.
             if 0 != j and 0 == j % bytes_per_chunk:
-                raw += ' '
+                raw += '  '
 
             # Convert to hex string.
             raw += ("%02X") % (b)
@@ -45,7 +45,7 @@ def hexdump(data: memoryview,
         text = text.ljust(bytes_per_line)
 
         # Append a new line in the output
-        dump.append(("%08X:  %s  |%s|") % (i, raw, text))
+        dump.append(("%08X     %s     %s") % (i, raw, text))
 
     return dump
 
@@ -54,9 +54,9 @@ def hexdump(data: memoryview,
 #     * 4 byte addresses
 #     * 16 bytes per line
 #     * 4 bytes per chunk
-#     * ASCII representation of bytes surrounded by '|' characters
+#     * ASCII representation of bytes
 DEFAULT_LINE_FORMAT = \
-    'AAAAAAAA:  DDDDDDDD DDDDDDDD DDDDDDDD DDDDDDDD  |CCCCCCCCCCCCCCCC|'
+    'AAAAAAAA     DDDDDDDD  DDDDDDDD  DDDDDDDD  DDDDDDDD     CCCCCCCCCCCCCCCC'
 
 
 def parse(lines: list,


### PR DESCRIPTION
There are existing tools in the service area that have worked for years on the format of this tool's predecessor's hex dump format, and a request was made to have peltool use the same format so that those tools can work.

Since I don't know of any tools parsing this current format, I agreed to the change.

New format:

```
"00000000     0000000A  712A2000  000D0026  000020A7     ....q* ....&.. .",
"00000010     B0021000  02B54000  494F2D4C  43532D42     ......@.IO-LCS-B",
```

Old format:
```
"00000000:  0000000A 712A2000 000D0026 000020A7  |....q* ....&.. .|",
"00000010:  B0021000 02B54000 494F2D4C 43532D42  |......@.IO-LCS-B|",
```