### PR TITLE
Fix JSON syntax error in procedure desc file

### DIFF
--- a/modules/calloutparsers/ocallouts/ocallouts.py
+++ b/modules/calloutparsers/ocallouts/ocallouts.py
@@ -30,7 +30,7 @@ procedures = {
 
     "BMC0007": [
         "A system data mismatch has been detected."
-    ]
+    ],
 
     "BMC0008": [
         "Failed parts present in the system. Service needed"


### PR DESCRIPTION
Fix a syntax error that was causing the callout procedure descriptions to not be displayed.