### PR TITLE
peltool: Add Config class

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -1,0 +1,9 @@
+class Config:
+    """
+    Holds configuration options.
+    """
+
+    def __init__(self) -> None:
+        self.allow_plugins = True
+        self.serviceable_only = False
+        self.non_serviceable_only = False


### PR DESCRIPTION
This class holds configuration options for peltool.

It should have been part of the previous commit but was missed.