### PR TITLE
peltool-wrapper: Bump version

### DIFF
--- a/peltool-wrapper/setup.py
+++ b/peltool-wrapper/setup.py
@@ -4,7 +4,7 @@ import os
 # This package is just used to install all of the component peltool
 # packages and doesn't contain any code of its own.
 
-version = os.getenv('PELTOOL_VERSION', '0.1')
+version = os.getenv('PELTOOL_VERSION', '0.2')
 
 setup(
     name        = "peltool-wrapper",


### PR DESCRIPTION
The previous commit added a python module to peltool-wrapper, so bump the package version so users can upgrade peltool-wrapper and have it pull in the new occ-pel-parser-module.