### PR TITLE
peltool: Handle bad JSON in from UD parsers

### DIFF
--- a/modules/pel/peltool/ext_user_data.py
+++ b/modules/pel/peltool/ext_user_data.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from pel.peltool.parse_user_data import ParseUserData
 from pel.peltool.comp_id import getDisplayCompID
 from pel.peltool.config import Config
+from pel.hexdump import hexdump
 import json
 
 
@@ -41,7 +42,14 @@ class ExtUserData:
 
         value = parser.parse(config)
 
-        j = json.loads(value)
+        try:
+            j = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            # This should have been valid JSON but if it isn't
+            # then hexdump it.
+            mv = memoryview(value.encode('utf-8'))
+            j = json.loads(json.dumps(hexdump(mv)))
+
         if not isinstance(j, dict):
             out['Data'] = j
         else:

--- a/modules/pel/peltool/user_data.py
+++ b/modules/pel/peltool/user_data.py
@@ -4,6 +4,7 @@ import json
 from pel.peltool.parse_user_data import ParseUserData
 from pel.peltool.comp_id import getDisplayCompID
 from pel.peltool.config import Config
+from pel.hexdump import hexdump
 
 
 class UserData:
@@ -38,7 +39,14 @@ class UserData:
 
         value = parser.parse(config)
 
-        j = json.loads(value)
+        try:
+            j = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            # This should have been valid JSON but if it isn't
+            # then hexdump it.
+            mv = memoryview(value.encode('utf-8'))
+            j = json.loads(json.dumps(hexdump(mv)))
+
         if not isinstance(j, dict):
             out['Data'] = j
         else:


### PR DESCRIPTION
The UserData parsers are supposed to return a string that contains valid JSON.  If they return invalid JSON then peltool will crash with a JSON exception.

Fix that by catching the JSON exception and printing a hexdump of the data instead.

This was happening when a UserData section that contained JSON (the built in JSON created by the BMC) was truncated in a large PEL so wasn't valid.