### PR TITLE
peltool: Add --termination option

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -7,3 +7,4 @@ class Config:
         self.allow_plugins = True
         self.serviceable_only = False
         self.non_serviceable_only = False
+        self.critSysTerm = False

--- a/modules/pel/peltool/pel_types.py
+++ b/modules/pel/peltool/pel_types.py
@@ -2,6 +2,11 @@ from enum import Enum, unique
 
 
 @unique
+class SeverityValues(Enum):
+    critSysTermSeverity = 0x51
+
+
+@unique
 class TransmissionState(Enum):
     newPEL = 0
     badPEL = 1


### PR DESCRIPTION
This commit introduces the -t/--termination option. 

Shows only pels with System Termination Critical Error. 
Can show pels based on given value

Tested on sample PEL files

Sample output:
```bash
{
    "0x50005679": {
        "SRC":                  "BC8A1B01",
        "PLID":                 "0x50005679",
        "CreatorID":            "BMC",
        "Subsystem":            "HostBoot",
        "Commit Time":          "04/25/2024 09:39:10",
        "Sev":                  "Critical Error, System Termination",
```

Signed-off-by: harsh-agarwal1 Harsh.Agarwal@ibm.com