### PR TITLE
peltool: Add -r option

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -470,6 +470,8 @@ def main():
                         action='store_true', help='Display all PELs')
     parser.add_argument('-n', '--show-pel-count', dest='show_pel_count',
                         action='store_true', help='Show number of PELs')
+    parser.add_argument('-r', '--reverse',
+                        action='store_true', help='Reverse order of output')
     if not inBMC:
         parser.add_argument('-p', '--path',
                         dest='path', help='Specify path to PELs')
@@ -528,7 +530,7 @@ def main():
         sys.exit(0)
 
     if args.list:
-        listOption(PELsPath, config, args.extension)
+        listOption(PELsPath, config, args.extension, args.reverse)
         sys.exit(0)
     
     if args.show_pel_count:
@@ -536,7 +538,7 @@ def main():
         sys.exit(0)
 
     if args.all:
-        extractAllPELsData(PELsPath, config, args.extension)
+        extractAllPELsData(PELsPath, config, args.extension, args.reverse)
         sys.exit(0)
 
     with open(args.file, 'rb') as fd:


### PR DESCRIPTION
This commit introduces the -r/--reverse option.
Reverses the output order for -l and -a option

Tested on sample PELs
Sample output:
```bash
$  python3 -m pel.peltool.peltool -p testfolder -l
{
    "0x50005507": {
        "SRC":                  "BD11E510",
...
$ python3 -m pel.peltool.peltool -p testfolder -l -r
{
    "0x50005679": {
        "SRC":                  "BC8A1B01",
...

```

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>