### PR TITLE
peltool: Allow to run peltool without module name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(
     packages     = find_packages("modules"),
     package_dir  = { "": "modules" },
     package_data = { "io_drawer": [ "mex_pte.h", "nimitz_pte.h",
-                                    "mexStringFile", "nimitzStringFile" ] }
+                                    "mexStringFile", "nimitzStringFile" ] },
+    scripts      = ['modules/pel/peltool/peltool.py']
 )


### PR DESCRIPTION
User can run peltool.py instead of long module name with the -m arg.
This will improve readability.

Tested on BMC and non-BMC system.
Sample:
```bash
$ peltool.py -h

$ python3 -m pel.peltool.peltool -h
```
Both above commands will fetch same results

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>