### PR TITLE
peltool: Add -d and -D option

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -273,14 +273,32 @@ def parseAndWriteOutput(file: str, output_dir: str, config: Config,
             print(f"No PEL parsed for {file}: {e}")
 
 
+def deleteAllPELs(path: str) -> None:
+    """
+    Delete all files in given path
+    Returns: None
+    """
+    root = ""
+    for root, _, files in os.walk(path):
+        for file in files:
+            if not os.path.isfile(os.path.join(root, file)):
+                continue
+            os.remove(os.path.join(root, file))
+        # Only process top level directory
+        break
+
+
 def process_pelID(pelID: str) -> str:
     """
     Processes a string by converting it to uppercase and removing the "0X" prefix if present.
     Returns: str: Processed pelID string.
     """
+    PEL_ID_LENGTH = 8
     pelID = pelID.upper()
     if pelID.startswith("0X"):
         pelID = pelID[2:]
+    if len(pelID) != PEL_ID_LENGTH:
+        sys.exit("Invalid length of PEL ID passed")
     return pelID
 
 def deletePELFromPELId(path: str, pelID: str) -> None:
@@ -543,6 +561,8 @@ def main():
                         action='store_true', help='Include hidden PELs')
     parser.add_argument('-d', '--del',
                         dest='IDToDelete', help='Delete a PEL based on its ID')
+    parser.add_argument('-D', '--delete-all', dest='deleteAll',
+                        action='store_true', help='Delete all PELs')
     if not inBMC:
         parser.add_argument('-p', '--path',
                         dest='path', help='Specify path to PELs')
@@ -614,6 +634,10 @@ def main():
 
     if args.IDToDelete:
         deletePELFromPELId(PELsPath, args.IDToDelete)
+        sys.exit(0)
+
+    if args.deleteAll:
+        deleteAllPELs(PELsPath)
         sys.exit(0)
 
     with open(args.file, 'rb') as fd:

--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -273,14 +273,43 @@ def parseAndWriteOutput(file: str, output_dir: str, config: Config,
             print(f"No PEL parsed for {file}: {e}")
 
 
+def process_pelID(pelID: str) -> str:
+    """
+    Processes a string by converting it to uppercase and removing the "0X" prefix if present.
+    Returns: str: Processed pelID string.
+    """
+    pelID = pelID.upper()
+    if pelID.startswith("0X"):
+        pelID = pelID[2:]
+    return pelID
+
+def deletePELFromPELId(path: str, pelID: str) -> None:
+    """
+    Search the PEL id in the given path and delete it.
+    Returns: None
+    """
+    pelID = process_pelID(pelID)
+    foundID = False
+    root = ""
+    for root, _, files in os.walk(path):
+        for file in files:
+            if pelID not in file:
+                continue
+            os.remove(os.path.join(root, file))
+            foundID = True
+            break
+        # Only process top level directory
+        break
+    if not foundID:
+        print("PEL not found")
+
+
 def parsePelFromID(path: str, pelID: str, config: Config) -> None:
     """
     Search the PEL id in the given path and prints the details.
     Returns: None
     """
-    pelID=pelID.upper()
-    if pelID.startswith("0X"):
-        pelID = pelID[2:]
+    pelID = process_pelID(pelID)
     foundID = False
     root = ""
     for root, _, files in os.walk(path):
@@ -486,9 +515,10 @@ def main():
                         action='store_true')
     parser.add_argument('-P', '--no-plugins', dest='skip_plugins',
                         action='store_true', help='Skip loading plugins')
-    parser.add_argument('-d', '--directory', dest='directory',
+    parser.add_argument('-j', '--json',
                         help='Process all files in a directory and save as <filename>.json.'
-                        ' Use -o to specify output directory')
+                        ' Use -o to specify output directory',
+                        action='store_true')
     parser.add_argument('-o', '--output-dir', dest='output_dir',
                         help='Directory to write output files when processing a directory')
     parser.add_argument('-e', '--extension', dest='extension',
@@ -511,6 +541,8 @@ def main():
                         action='store_true', help='Reverse order of output')
     parser.add_argument('-H', '--hidden',
                         action='store_true', help='Include hidden PELs')
+    parser.add_argument('-d', '--del',
+                        dest='IDToDelete', help='Delete a PEL based on its ID')
     if not inBMC:
         parser.add_argument('-p', '--path',
                         dest='path', help='Specify path to PELs')
@@ -534,31 +566,6 @@ def main():
     if args.hidden:
         config.hidden = True
 
-    if args.directory:
-        if not os.path.isdir(args.directory):
-            sys.exit(f"{args.directory} is not a valid directory")
-
-        output_dir = args.directory
-        if args.output_dir:
-            if not os.path.isdir(args.output_dir):
-                sys.exit(f"Output directory {args.output_dir} doesn't exist")
-
-            output_dir = args.output_dir
-
-        for root, _, files in os.walk(args.directory):
-            for file in files:
-                if args.extension and args.extension != os.path.splitext(file)[1]:
-                    continue
-
-                parseAndWriteOutput(os.path.join(
-                    root, file), output_dir, config,
-                    args.delete)
-
-            # Only process top level directory
-            break
-
-        sys.exit(0)
-
     if not inBMC:
         if not args.file:
             if not args.path:
@@ -566,6 +573,24 @@ def main():
             if not os.path.isdir(args.path):
                 sys.exit(f"{args.path} is not a valid directory")
             PELsPath = args.path
+
+    if args.json:
+        output_dir = PELsPath
+        if args.output_dir:
+            if not os.path.isdir(args.output_dir):
+                sys.exit(f"Output directory {args.output_dir} doesn't exist")
+            output_dir = args.output_dir
+
+        for root, _, files in os.walk(PELsPath):
+            for file in files:
+                if args.extension and args.extension != os.path.splitext(file)[1]:
+                    continue
+                parseAndWriteOutput(os.path.join(
+                    root, file), output_dir, config,
+                    args.delete)
+            # Only process top level directory
+            break
+        sys.exit(0)
 
     if args.pelID:
         parsePelFromID(PELsPath, args.pelID, config)
@@ -585,6 +610,10 @@ def main():
 
     if args.all:
         extractAllPELsData(PELsPath, config, args.extension, args.reverse)
+        sys.exit(0)
+
+    if args.IDToDelete:
+        deletePELFromPELId(PELsPath, args.IDToDelete)
         sys.exit(0)
 
     with open(args.file, 'rb') as fd:


### PR DESCRIPTION
This PR introduces the -d and -D option.
Delete a PEL based on its ID
Delete all PELs

This PR also changes older -d/--directory to -j/--json
Tested on sample PELs
Sample output:
```bash
$ peltool.py -j -p testpels2/ -o jsonout/

$ peltool.py -p deltest/ -d 0x50005507

$ peltool.py -p deltest/ -d 0x50005507
PEL not found

$ peltool.py -p deltest/ -D

$ peltool.py -p deltest/ -l
{}
```

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>