### PR TITLE
peltool: Fix, EID is unique for the PEL so use EID instead of PLID

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -389,7 +389,7 @@ def parsePELSummary(stream: DataStream, config: Config):
     ret, ph = generatePH(stream, out)
     if ret is False:
         return "", ""
-    eid = ph.pLID
+    eid = ph.lEID
     ret, uh = generateUH(stream, ph.creatorID, out)
     if ret is False:
         return "", ""


### PR DESCRIPTION
For BMC PELs, lEID and pLID are same, 
Not necessary for PHYP ones.
Hence, fixing eid of -l option from pLID to lEID

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>