### PR TITLE
peltool: Add -S option

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -9,3 +9,4 @@ class Config:
         self.non_serviceable_only = False
         self.critSysTerm = False
         self.hidden = False
+        self.severities = []

--- a/modules/pel/peltool/pel_values.py
+++ b/modules/pel/peltool/pel_values.py
@@ -182,6 +182,19 @@ severityValues = {
 
 
 """
+The possible severity groups with there distinct starting hex digit. 
+"""
+severityGroupValues = {
+    'Informational': 0, 
+    'Recovered':     1, 
+    'Predictive':    2, 
+    'Unrecoverable': 4, 
+    'Critical':      5, 
+    'Diagnostic':    6, 
+    'Symptom':       7}
+
+
+"""
 The possible values for the Action Flags field in the User Header.
 """
 actionFlagsValues = {


### PR DESCRIPTION
This commit introduces the -S/--severity option.
Using this option we can filter by severity. 
We consider pels matching the provided category only.

Tested on sample PELs
Sample output:
```bash
$ peltool.py -p testpels/ -l -S Unrecoverable Predictive
{
    "0x50000BE1": {
        "SRC":                  "BD554002",
        "PLID":                 "0x50000BE1",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - VPD Interface",
        "Commit Time":          "06/11/2024 18:05:03",
        "Sev":                  "Predictive Error",
...

$ peltool.py -p testpels/ -l -S Unrecoverable
{
    "0x900001EB": {
        "SRC":                  "BC8A2BC0",
        "PLID":                 "0x900001EB",
        "CreatorID":            "Hostboot",
        "Subsystem":            "HostBoot",
        "Commit Time":          "06/11/2024 18:06:31",
        "Sev":                  "Unrecoverable Error",
...

$ peltool.py -p testpels/ -l -S Unrecoverab
usage: peltool.py [-h] [-f FILE] [-s] [-N] [-P] [-j] [-o OUTPUT_DIR] [-e EXTENSION] [-c] [-t] [-i PELID] [--bmc-id BMCID] [-l] [-a] [-n] [-r] [-H] [-d IDTODELETE]
                  [-D]
                  [-S {Informational,Recovered,Predictive,Unrecoverable,Critical,Diagnostic,Symptom} [{Informational,Recovered,Predictive,Unrecoverable,Critical,Diagnostic,Symptom} ...]]
                  [-p PATH]
peltool.py: error: argument -S/--severity: invalid choice: 'Unrecoverab' (choose from 'Informational', 'Recovered', 'Predictive', 'Unrecoverable', 'Critical', 'Diagnostic', 'Symptom')
```

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>
