### PR TITLE
peltool: Refined help function of -e option

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -540,7 +540,7 @@ def main():
     parser.add_argument('-o', '--output-dir', dest='output_dir',
                         help='Directory to write output files when processing a directory')
     parser.add_argument('-e', '--extension', dest='extension',
-                        help='Used with -d, only look for files with this extension (e.g. ".pel")')
+                        help='Only look for files with this extension (e.g. ".pel")')
     parser.add_argument('-c', '--clean', dest='clean', action='store_true',
                         help='Delete original file after parsing')
     parser.add_argument('-t', '--termination', dest='critSysTerm',


### PR DESCRIPTION
-e option is no more limited to -d option.
Therefore changing help, to avoid potential confusion

Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>