### PR TITLE
Add --archive peltool option for BMC

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -528,6 +528,7 @@ def printPELCount(path: str, config: Config, extension: str):
 
 def main():
     PELsPath = "/var/lib/phosphor-logging/extensions/pels/logs/"
+    PELsArchivePath = "/var/lib/phosphor-logging/extensions/pels/logs/archive"
     inBMC = os.path.isdir(PELsPath)
     parser = argparse.ArgumentParser(description="PELTools")
 
@@ -574,6 +575,10 @@ def main():
     if not inBMC:
         parser.add_argument('-p', '--path',
                         dest='path', help='Specify path to PELs')
+    else:
+        # peltool -A/--archive is specific to BMC only.
+        parser.add_argument('-A', '--archive',
+                        action='store_true', help='List or display archived PELs')
 
     args = parser.parse_args()
 
@@ -606,6 +611,10 @@ def main():
         if not os.path.isdir(args.path):
             sys.exit(f"{args.path} is not a valid directory")
         PELsPath = args.path
+    else:
+        # peltool -A/--archive is specific to BMC only.
+        if args.archive:
+            PELsPath = PELsArchivePath
 
     if args.json:
         output_dir = PELsPath


### PR DESCRIPTION

- This commit enables peltool --archive option for BMC.
```
  -A, --archive         List or display archived PELs
```

- This option is not listed on non-BMC environment
```
peltool.py: error: unrecognized arguments: --archive
```

### Tested with sample PELs on BMC environment.

Few example outputs:

- Incase of archive PELs present

```
python3 -m pel.peltool.peltool -l --archive
{
    "0x5000599E": {
        "SRC":                  "BD13E510",
        "Message":              "Error Signature: 0x20da0020 0x1 0x5074001d",
        "PLID":                 "0x5000599E",
        "CreatorID":            "BMC",
        "Subsystem":            "Processor Unit (CPU)",
        "Commit Time":          "04/29/2024 08:51:09",
        "Sev":                  "Unrecoverable Error",
        "CompID":               "bmc hw diags"
    },
  ```
- Incase of no archive PELs
```
python3 -m pel.peltool.peltool -l --archive
{}
```
- Incase of archive PELs to display in reverse use
```
python3 -m pel.peltool.peltool -l --archive -r
```