### PR TITLE
Add -x/--hex peltool option

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -9,4 +9,5 @@ class Config:
         self.non_serviceable_only = False
         self.critSysTerm = False
         self.hidden = False
+        self.hex = False
         self.severities = []


### PR DESCRIPTION
- This commit enables peltool -x/--hex option.

```
 -x, --hex             Display PEL(s) in hexdump instead of JSON
```

- Sample output

Note: A line separator 'PEL Begin' and 'PEL End' is added before and after displaying pel in hexdecimal format.

```
-------------- PEL Begin  ----------------
00000000     50480030  0100526D  20250625  06414000     PH.0..Rm %.%.A@.
00000010     20250625  06421106  48000006  000001E3      %.%.B..H.......
00000020     00000000  00000000  82000C22  5000805C     ..........."P..\
00000030     55480018  01004552  82030001  00000000     UH....ER........
00000040     00002000  00000003  50530050  01004552     .. .....PS.P..ER
00000050     02000009  00000048  30000000  00000000     .......H0.......
00000060     00000000  00000000  00000000  00000000     ................
00000070     00000000  00000000  42373030  30363231     ........B7000621
00000080     20202020  20202020  20202020  20202020
00000090     20202020  20202020  4548004C  01004552             EH.L..ER
000000A0     39303238  2D323142  31333741  41313120     9028-21B137AA11
000000B0     00000000  4E4C3130  36305F30  35380000     ....NL1060_058..
000000C0     00000000  30303034  30413036  30393736     ....00040A060976
000000D0     30303030  00000000  00000000  00000000     0000............
000000E0     00000000  4D54001C  01004552  39303238     ....MT....ER9028
000000F0     2D323142  31333741  41313120  00000000     -21B137AA11 ....
00000100     55440070  00000000  00000000  00000000     UD.p............
00000110     00000000  00000000  00000000  00000000     ................
00000120     00000000  00000000  00000000  00000000     ................
00000130     ADB5E818  7F100000  00000000  00000000     ................
00000140     00000000  00030000  00000000  00000000     ................
00000150     ADAF960E  8C266000  10000000  00000000     .....&`.........
00000160     00000000  00000000  10065209  F2EA0000     ..........R.....
-------------- PEL End    -----------------
```

- Tested the -x/--hex option with other peltool option as mentioned below
```
python3 peltool.py -l -x
python3 peltool.py -l -H -x
python3 peltool.py -l -r -x
python3 peltool.py -l -H -r -x
python3 peltool.py -l -S Predictive -x
python3 peltool.py -l --archive -x
python3 peltool.py --bmc-id 461 -x
python3 peltool.py -a -x
python3 peltool.py -i 0x890000CC -x
python3 peltool.py -f /var/lib/phosphor-logging/extensions/pels/logs/2025062506421106_5000805C -x

```