### PR TITLE
Add --plid and --src option

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -14,3 +14,5 @@ class Config:
         self.extension = None
         self.severities = []
         self.only = False
+        self.plid = None
+        self.src = None


### PR DESCRIPTION
Implement --plid and --src option

- --plid option displays PELs matched with given Platform Log ID and
  --src displays PELs matched with given System Reference code from
  the overall serviceable,non-serviceable, hidden PELs
```
  --plid PLID           Display PELs based on its Platform Log ID
  --src SRC             Display PELs based on its System Reference Code 
```

- Tested changes on BMC environment.
-  Sample output with --plid option

```
> python3 peltool.py --plid 8900006F
{
    "0x8900006F": {
        "SRC":                  "BC13E504",
        "PLID":                 "0x8900006F",
        "CreatorID":            "Hostboot",
        "Subsystem":            "Processor Unit (CPU)",
        "Commit Time":          "07/12/2025 05:24:35",
        "Sev":                  "Recovered Error",
        "CompID":               "hostboot: prdf"
    }
}

> python3 peltool.py --plid 0x8900023
Invalid length of ID is provided !

> python3 peltool.py --plid 0x89000071 -r
> python3 peltool.py --plid 0x89000071 -x
> python3 peltool.py --plid 0x89000071 --archive
```
-  Sample output with --src option
```
 python3 peltool.py --src BC20E504
{
    "0x89000071": {
        "SRC":                  "BC20E504",
        "PLID":                 "0x89000071",
        "CreatorID":            "Hostboot",
        "Subsystem":            "Memory ",
        "Commit Time":          "07/12/2025 06:10:02",
        "Sev":                  "Predictive Error",
        "CompID":               "hostboot: prdf"
    }
}

> python3 peltool.py --src BC20E50401111111111111111111111111111111
Invalid SRC ID length is provided !

> python3 peltool.py --src BC20E504 -r
> python3 peltool.py --src BC20E504 -x
> python3 peltool.py --src BC20E504 --archive
```