### PR TITLE
Add --src-exclude option

### DIFF
--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -18,3 +18,4 @@ class Config:
         self.src = None
         self.bmcID = None
         self.pelID = None
+        self.srcExcludeFile = None

--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -503,6 +503,10 @@ def parsePelFromSRCID(path: str, config: Config):
         if len(config.src) > 32:
             sys.exit('Invalid SRC length is provided!')
 
+    if config.srcExcludeFile:
+        with open(config.srcExcludeFile, 'r') as fd:
+            src_exclude_file_data = fd.read()
+
     root, file_list = getFileList(path, config.extension, config.rev)
     final_summary = {}
     for file in file_list:
@@ -517,6 +521,13 @@ def parsePelFromSRCID(path: str, config: Config):
                             printPELInHexFormat(data)
                         else:
                             final_summary[eid] = summary
+                    if (config.srcExcludeFile):
+                        if summary['SRC'] not in src_exclude_file_data:
+                            if config.hex:
+                                printPELInHexFormat(data)
+                            else:
+                                final_summary[eid] = summary
+
             except Exception as e:
                 print(f"Exception: No PEL parsed for {file}: {e}")
     if not config.hex:
@@ -734,6 +745,8 @@ def main():
                         dest='plID', help='Display PELs based on its Platform Log ID')
     parser.add_argument('--src',
                         dest='src', help='Display PELs based on its System Reference Code')
+    parser.add_argument('--src-exclude',
+                        dest='src_exclude_file', help='Display PELs excluding SRCs from the file')
     parser.add_argument('-l', '--list',
                         action='store_true', help='List PELs')
     parser.add_argument('-a', '--all-pels', dest='all',
@@ -849,6 +862,13 @@ def main():
 
     if args.src:
         config.src = args.src
+        parsePelFromSRCID(PELsPath, config)
+        sys.exit(0)
+
+    if args.src_exclude_file:
+        config.srcExcludeFile = args.src_exclude_file
+        if not os.path.isfile(config.srcExcludeFile):
+            sys.exit(f"Input {config.srcExcludeFile} file doesn't exist!")
         parsePelFromSRCID(PELsPath, config)
         sys.exit(0)
 


### PR DESCRIPTION
Implement --src-exclude option
```
-src-exclude SRC_EXCLUDE_FILE    Display PELs excluding SRCs from the file
```
- Tested changes on BMC environment.

- Sample src_exclude_file file
  - src_exclude_file supports any format, few examples are mentioned below.
```
>cat src_exclude_file
BC20E504B7006A26
BC13E504

>cat src_exclude_file
BC20E504, B7006A26, BC13E504

>cat src_exclude_file
BC20E504, B7006A26
BC13E504

>cat src_exclude_file
BC20E504 B7006A26 BC13E504
```

```
python3 peltool.py --src-exclude ~/src_exclude
{
    "0x500082DB": {
        "SRC":                  "110015F0",
        "Message":              "A power supply has indicated an input or under voltage condition.",
        "PLID":                 "0x500082DB",
        "CreatorID":            "BMC",
        "Subsystem":            "Power Supply",
        "Commit Time":          "07/20/2025 10:53:20",
        "Sev":                  "Unrecoverable Error",
        "CompID":               "bmc power and thermal"
    }
}

python3 peltool.py --src-exclude ~/src_exclude
{}

python3 peltool.py --src-exclude dummy
Input dummy file doesn't exist!

python3 peltool.py --src-exclude ~/src_exclude -H
python3 peltool.py --src-exclude ~/src_exclude -x
python3 peltool.py --src-exclude ~/src_exclude --archive
python3 peltool.py --src-exclude ~/src_exclude -r
```