### PR TITLE
Peltool: Added new action flag value

### DIFF
--- a/modules/pel/peltool/pel_values.py
+++ b/modules/pel/peltool/pel_values.py
@@ -191,7 +191,8 @@ actionFlagsValues = {
     0x1000: "Do Not Report To Hypervisor",
     0x0800: "HMC Call Home",
     0x0400: "Isolation Incomplete, further analysis required",
-    0x0100: "Service Processor Call Home Required"}
+    0x0100: "Service Processor Call Home Required",
+    0x0020: "Heartbeat Call Home Event"}
 
 """
 Map for transmission states


### PR DESCRIPTION
Defined new entry in PEL values action flags field to incorporate 
updated PEL spec error action flag bit#10.

Tested:
Sample output:
Old:
```bash
python3 -m pel.peltool.peltool -f 2024092414360909_500055AC
...
"Action Flags": [
            "Report Externally"
        ],
...
```
New:
```bash
"Action Flags": [
            "Report Externally",
            "Heartbeat Call Home Event"
        ],
```

Signed-off-by: Harsh Agarwal Harsh.Agarwal@ibm.com