### PR TITLE
Peltool: Performance improvement

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -625,7 +625,9 @@ def extractAllPELsData(path: str, config: Config):
     Prints a JSON-formatted string containing PEL data from all valid files.
     """
     root, file_list = getFileList(path, config.extension, config.rev)
-    allPELsData = "[ \n"
+    if not config.hex:
+        print("[")
+    firstPELPrinted = False
     for file in file_list:
         with open(os.path.join(root, file), 'rb') as fd:
             data = fd.read()
@@ -634,14 +636,18 @@ def extractAllPELsData(path: str, config: Config):
                 _, json_string = parsePEL(stream, config, False)
                 if json_string:
                     if not config.hex:
-                        allPELsData = allPELsData + json_string + ",\n"
+                        if firstPELPrinted:
+                            print(",")
+                        print(json_string, end = "")
+                        firstPELPrinted = True
                     else:
                         printPELInHexFormat(data)
             except Exception as e:
                 print(f"Exception: No PEL parsed for {file}: {e}", file=sys.stderr)
     if not config.hex:
-        allPELsData = allPELsData[:-2] + "\n]"
-        print(allPELsData)
+        if firstPELPrinted:
+            print()
+        print("]")
 
 
 def printPELInHexFormat(data: memoryview) -> None:

--- a/modules/srcparsers/osrc/osrc.py
+++ b/modules/srcparsers/osrc/osrc.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 
+osrcParsers = {}
 
 def parseSRCToJson(refcode: str,
                    word2: str, word3: str, word4: str, word5: str,
@@ -39,18 +40,26 @@ def parseSRCToJson(refcode: str,
         module_name = '.'.join(['srcparsers', name, name])
 
     try:
-        # Grab the module if it exist. If not, it will throw an exception.
-        module = importlib.import_module(module_name)
-
+        if module_name in osrcParsers:
+            module = osrcParsers[module_name]
+        else:
+            # Grab the module if it exist. If not, it will throw an exception.
+            module = importlib.import_module(module_name)
+            osrcParsers[module_name] = module
     except ModuleNotFoundError:
+        osrcParsers[module_name] = None
         # The module does not exist. No need to parse the SRC. Using
         # 'json.dumps()' here so that it returns the JSON 'null' value.
         out = json.dumps(None)
 
     else:
-        # The module was found. Call the component parser in that module.
-        out = module.parseSRCToJson(refcode,
-                                    word2, word3, word4, word5,
-                                    word6, word7, word8, word9)
+        if module is None:
+            # The module, which was previously checked, is not found.
+            out = json.dumps(None)
+        else:
+            # The module was found. Call the component parser in that module.
+            out = module.parseSRCToJson(refcode,
+                                        word2, word3, word4, word5,
+                                        word6, word7, word8, word9)
 
     return out


### PR DESCRIPTION
Enhances performance of -a option by printing as soon as each PEL 
is parsed. 
This change minimizes the overhead associated with storing and 
processing large strings, resulting in faster output generation.

Tested Non-BMC env:
```bash
time python3 -m pel.peltool.peltool -a -p 3kpels/
1m3.707s    ->  0m38.749s
```

Optimize performance by implementing caching mechanisms for
component IDs, user data parsers, callout parsers, and SRC
modules.
These changes reduce redundant module imports by storing previously
loaded modules in dictionaries, streamlining the parsing process
and enhancing overall efficiency.

Tested:
```bash
Non-BMC env:
-n: 0.941s    ->  0.283s
-l: 6.100s    ->  4.225s
-a: 52.740s   ->  17.371s

BMC env:
-n: 4.287s   ->  4.217s
-l: 1m24.911s ->  14.125s
-a: 1m37.431s ->  24.958s
```

Signed-off-by: Harsh Agarwal Harsh.Agarwal@ibm.com