### PR TITLE
Peltool: Caching partial function call results

### DIFF
--- a/modules/pel/peltool/comp_id.py
+++ b/modules/pel/peltool/comp_id.py
@@ -3,7 +3,10 @@ import os
 import json
 
 componentIDs = {}
-
+basePath = '/usr/share/phosphor-logging/pels/'
+basePathPresent = os.path.exists(basePath)
+overallCheckCompIDFilePath, importSuccess = True, True
+checkCompIDFilePath = [overallCheckCompIDFilePath, importSuccess, basePathPresent]
 
 def getCompIDFilePath(creatorID: str) -> str:
     """
@@ -11,15 +14,19 @@ def getCompIDFilePath(creatorID: str) -> str:
     The pel_registry module isn't available on the BMC,
     so just look in /usr/share/... if that module isn't present.
     """
-    try:
-        import pel_registry
-        file = pel_registry.get_comp_id_file_path(creatorID)
-    except ModuleNotFoundError:
+    file = basePath
+    if checkCompIDFilePath[1]:
+        try:
+            import pel_registry
+            file = pel_registry.get_comp_id_file_path(creatorID)
+            return file
+        except ModuleNotFoundError:
+            checkCompIDFilePath[1] = False
+            checkCompIDFilePath[0] = checkCompIDFilePath[2]
+    if checkCompIDFilePath[2]:
         # Use the BMC path
-        basePath = '/usr/share/phosphor-logging/pels/'
         name = creatorID + '_component_ids.json'
-        file = os.path.join(os.path.join(basePath, name))
-
+        file = os.path.join(basePath, name)
     return file
 
 
@@ -40,10 +47,11 @@ def getDisplayCompID(componentID: int, creatorID: str) -> str:
 
     # try the comp IDs file named after the creator ID
     if creatorID not in componentIDs:
-        compIDFile = getCompIDFilePath(creatorID)
-        if os.path.exists(compIDFile):
-            with open(compIDFile, 'r') as file:
-                componentIDs[creatorID] = json.load(file)
+        if checkCompIDFilePath[0]:
+            compIDFile = getCompIDFilePath(creatorID)
+            if os.path.exists(compIDFile):
+                with open(compIDFile, 'r') as file:
+                    componentIDs[creatorID] = json.load(file)
 
     compIDStr = '{:04X}'.format(componentID).upper()
     if creatorID in componentIDs and compIDStr in componentIDs[creatorID]:


### PR DESCRIPTION
Optimize performance by caching partial function call results to 
minimize redundant checks.
'getCompIDFilePath' function is called multiple time for a single 
PEL(~6x), caching helps with redundant calls.

Tested:
```bash
Non-BMC env:
-n: 1.070s    ->  0.286s
-l: 5.717s    ->  3.947s
-a: 1m22.010s ->  1m11.011s

BMC env:
-n: 4.311s    ->  4.220s
-l: 1m24.911s ->  1m24.843s
-a: 4m57.089s ->  4m45.430s

with PR69:
 In BMC env:
 -a: 1m38.180s -> 1m37.438s
 In non-BMC env:
 -a: 52.241s   -> 49.331s
```

Signed-off-by: Harsh Agarwal Harsh.Agarwal@ibm.com