### PR TITLE
Peltool: Add -E/--every-pel option

### DIFF
--- a/modules/pel/peltool/README.md
+++ b/modules/pel/peltool/README.md
@@ -9,6 +9,7 @@ To see all of peltool's capabilities, use the help option `peltool.py --help`.
 ## List PELs
 
 - Get list of PELs: `peltool.py -l` (By default serviceable PELs are listed)
+- Get list of all PEL irrespective of PEL type: `peltool.py -lE`
 - Get list of PELs including non-serviceable PELs: `peltool.py -lN`
 - Get list of PELs including hidden PELs: `peltool.py -lH`
 - Get list of PELs including terminating PELs: `peltool.py -lt`
@@ -25,6 +26,7 @@ To see all of peltool's capabilities, use the help option `peltool.py --help`.
 ## Show PEL Count
 
 - Get PEL count: `peltool.py -n` (By default serviceable PELs count is given)
+- Get all PEL count irrespective of PEL type: `peltool.py -nE`
 - Get PEL count including non-serviceable PELs: `peltool.py -nN`
 - Get PEL count including hidden PELs: `peltool.py -nH`
 - Get PEL count including terminating PELs: `peltool.py -nt`
@@ -41,6 +43,7 @@ To see all of peltool's capabilities, use the help option `peltool.py --help`.
 ## Display all PEL data
 
 - Get all PEL data: `peltool.py -a` (By default serviceable PELs data are displayed)
+- Get all PEL data irrespective of PEL type: `peltool.py -aE`
 - Get all PEL data including hidden PELs: `peltool.py -aH`
 - Get all PEL data including terminating PELs: `peltool.py -at`
 - Get all PEL data for serviceable, non-serviceable, and hidden PELs: `peltool.py -asNH`

--- a/modules/pel/peltool/config.py
+++ b/modules/pel/peltool/config.py
@@ -7,6 +7,7 @@ class Config:
         self.allow_plugins = True
         self.serviceable = False
         self.non_serviceable = False
+        self.every_pel = False
         self.critSysTerm = False
         self.hidden = False
         self.hex = False

--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -219,6 +219,9 @@ def considerPEL(uh: UserHeader, config: Config) -> bool:
     Returns True if the PEL should be considered, False otherwise.
     """
 
+    if config.every_pel:
+        return True
+
     if config.critSysTerm and uh.eventSeverity == SeverityValues.critSysTermSeverity.value:
         return True
 
@@ -729,6 +732,7 @@ def main():
 
         List servicable PELs: {0} -l
         List informational PELs along with serviceable PELs: {0} -l -S Informational
+        List every PEL irrespective of its type: {0} -l -E
         List only hidden PELs: {0} -l -H -O
         List only unrecoverable PELs: {0} -l -O -S Unrecoverable
         Count only hidden PELs: {0} -n -H -O
@@ -789,6 +793,8 @@ def main():
                                              'Use below options along with -l/--list, '
                                              '-a/--all, -n/--show-pel-count options. '
                                              'Check example usage')
+    pelExclusive.add_argument('-E', '--every-pel', action='store_true',
+                              help='Operate on every single PEL')
     pelExclusive.add_argument('-s', '--serviceable', action='store_true',
                               help='Get Serviceable PELs')
     pelExclusive.add_argument('-N', '--non-serviceable', action='store_true',
@@ -837,6 +843,9 @@ def main():
 
     if args.only:
         config.only = True
+
+    if args.every_pel:
+        config.every_pel = True
 
     if args.severities:
         config.severities.extend(severityGroupValues[sev] for sev in args.severities)


### PR DESCRIPTION
This commit introduces the -E/--every-pel option.
We consider all the pels in the default/specified folder.

Tested on sample PELs
Sample output:
```bash
$ peltool.py -p tpels/ -n
{
    "Number of PELs found": 7
}

$ peltool.py -p tpels/ -En
{
    "Number of PELs found": 13
}
```