### PR TITLE
peltool: Modify -f option

### DIFF
--- a/modules/pel/peltool/peltool.py
+++ b/modules/pel/peltool/peltool.py
@@ -860,6 +860,7 @@ def main():
         config.extension = args.extension
 
     if args.file:
+        config.every_pel = True
         parseAndPrintPELFile(args.file, config, True)
         if args.clean:
             os.remove(args.file)


### PR DESCRIPTION
This commit updates the behavior of -f/--file option. 
Previously, certain PEL files were ignored due to the default behavior.
With this change, we consider any PEL file passed to it.

Tested on sample PELs
Sample output:
```bash
$ peltool.py -f tpels/2022031117260306_89000119

$ peltool.py -f tpels/2022031117260306_89000119
{
    "Private Header": {
        "Section Version":           1,
...
```